### PR TITLE
Fix: erroring on use of shorthand arrow function

### DIFF
--- a/packages/babel-plugin-minify-simplify/__tests__/simplify-test.js
+++ b/packages/babel-plugin-minify-simplify/__tests__/simplify-test.js
@@ -681,6 +681,16 @@ describe('simplify-plugin', () => {
     expect(transform(source)).toBe(expected);
   });
 
+  it('earlyReturnTransform: it shouldn\'t error on shorthand arrow functions', () => {
+    const source = unpad(`
+      const f = () => a;
+    `);
+    const expected = unpad(`
+      const f = () => a;
+    `);
+    expect(transform(source)).toBe(expected);
+  });
+
   it('should merge function blocks into sequence expressions', () => {
     const source = unpad(`
       function foo() {

--- a/packages/babel-plugin-minify-simplify/src/index.js
+++ b/packages/babel-plugin-minify-simplify/src/index.js
@@ -1482,6 +1482,10 @@ module.exports = ({ Plugin, types: t }) => {
   function earlyReturnTransform(path) {
     const { node } = path;
 
+    if (!t.isBlockStatement(node.body)) {
+      return;
+    }
+
     for (let i = node.body.body.length; i >= 0; i--) {
       const statement = node.body.body[i];
       if (t.isIfStatement(statement) && !statement.alternate &&


### PR DESCRIPTION
```
function a() {}

(function() {})

var b = { c() {} }
class D { e() {} }

var f = () => {}
var f = () => a
```

For the shorthand arrow function with a `BlockStatement`, `var f = () => a`, it won't have `node.body.body`. In the example `node.body.type === "Identifier"`

This is the same check in `earlyContinueTransform`
