### PR TITLE
Update lerna

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.0.0-beta.23",
+  "lerna": "2.0.0-beta.24",
   "version": "0.0.0",
   "publishConfig": {
     "ignore": [

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "gulp-newer": "^1.1.0",
     "gulp-util": "^3.0.7",
     "jest-cli": "^0.6.1",
-    "lerna": "^2.0.0-beta.23",
+    "lerna": "2.0.0-beta.24",
     "through2": "^2.0.1",
     "uglify-js": "^2.6.2"
   }


### PR DESCRIPTION
- Change to fixed version as lerna.json uses a fixed version and we
  cannot have ^2.0.0-beta.23 as the installation would conflict with the
  version in lerna.json
