### PR TITLE
Rearrange travis script step to run all tasks even if one fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,8 @@ node_js:
 - '6'
 - '5'
 
-script: npm run bootstrap && npm run build && npm run test
+script:
+- npm run bootstrap
+- npm run build
+- npm run lint
+- npm run test

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "updated": "lerna updated",
     "lint": "eslint packages/*/src packages/*/__tests__",
     "fix": "eslint packages/*/src packages/*/__tests__ --fix",
-    "test": "npm run lint && jest",
+    "test": "jest",
     "build": "gulp build",
     "watch": "gulp watch",
     "ci": "npm run lint && npm run bootstrap && jest"


### PR DESCRIPTION
Why?

Even if the lint fails, sometimes we want to check if there is a test that's failing. It has been useful for me and have noticed this pattern with a few others that even if one test fails they still want to see the results of other tests in the pipeline.

Makes sense ?
