### PR TITLE
Fix for dev - ignore all node_modules - linked modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
       "packages"
     ],
     "preprocessorIgnorePatterns": [
-      "<rootDir>/node_modules/"
+      "/node_modules/"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
When using linked(using npm link) modules, jest doesn't ignore the node_modules in the linked modules. This is to ignore all node_modules.

Linking babel, results in error = `$exports is not defined` when running tests.
