### PR TITLE
add # of plugin visits

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ uglify  21.82kB 220%    7.32kB 169%     1ms        359ms
 closure 21.67kB 223%    7.37kB 167%     2ms        3455ms
 ```
 
-Run with: ``./scripts/benchmark.js ./scripts/fixtures/backbone.js`
+Run with: `./scripts/benchmark.js ./scripts/fixtures/backbone.js`
 
 React:
 ```
@@ -127,7 +127,7 @@ closure 171.46kB 265%    52.97kB 168%     12ms       9785ms
 uglify  176.41kB 255%    53.18kB 167%     12ms       2187ms
 ```
 
-Run with: ``./scripts/benchmark.js ./scripts/fixtures/react.js`
+Run with: `./scripts/benchmark.js ./scripts/fixtures/react.js`
 
 jQuery:
 ```
@@ -137,4 +137,4 @@ babel   93.63kB 220%    32.95kB 156%     8ms        3623ms
 closure 94.23kB 218%    33.38kB 153%     10ms       9001ms
 ```
 
-Run with: ``./scripts/benchmark.js ./scripts/fixtures/jquery.js`
+Run with: `./scripts/benchmark.js ./scripts/fixtures/jquery.js`

--- a/scripts/plugin-timing.js
+++ b/scripts/plugin-timing.js
@@ -15,6 +15,7 @@ class Benchmark {
     }
   } = {}) {
     this.events = {};
+    this.visits = {};
     this.results = {};
     this.now = now;
     this.diff = diff;
@@ -22,8 +23,10 @@ class Benchmark {
   push(name) {
     if (!hop(this.events, name)) {
       this.events[name] = [];
+      this.visits[name] = 0;
     }
     this.events[name].push(this.now());
+    this.visits[name]++;
   }
   pop(name) {
     if (hop(this.events, name) && (this.events[name].length > 0)) {
@@ -59,7 +62,7 @@ function run (file) {
   });
 
   const table = new Table({
-    head: ["pluginAlias", "time(ms)"],
+    head: ["pluginAlias", "time(ms)", "# visits", "time/visit(ms)"],
     chars: {
       top: "",
       "top-mid": "" ,
@@ -86,13 +89,13 @@ function run (file) {
 
   const results = Object
     .keys(b.results)
-    .map((name) => [name, b.results[name].aggregate])
+    .map((name) => [name, b.results[name].aggregate, b.visits[name]])
     .sort((a, b) => {
       if (a[1] < b[1]) return 1;
       if (a[1] > b[1]) return -1;
       return 0;
     })
-    .map((arr) => [arr[0], arr[1].toFixed(3)]);
+    .map((arr) => [arr[0], arr[1].toFixed(3), arr[2], (arr[1]/arr[2]).toFixed(3)]);
 
   table.push(...results);
   console.log(table.toString());


### PR DESCRIPTION
Not actually sure how useful this is anymore but figured I'd post it anyway.

```
./scripts/plugin-timing.js ./scripts/fixtures/jquery.js
pluginAlias                             time(ms) # visits time/visit(ms)
minify-simplify                         2461.853 53786    0.046
minify-mangle-names                     1785.353 1        1785.353
minify-constant-folding                 776.446  124070   0.006
minify-guarded-expressions              358.347  11517    0.031
minify-dead-code-elimination            250.410  1        250.410
minify-infinity                         109.801  56557    0.002
internal.shadowFunctions                105.693  57862    0.002
transform-undefined-to-void             99.388   56557    0.002
minify-type-constructors                59.929   7575     0.008
transform-simplify-comparison-operators 47.390   4845     0.010
transform-member-expression-literals    32.877   17182    0.002
minify-flip-comparisons                 17.091   4845     0.004
transform-merge-sibling-variables       7.737    1748     0.004
internal.blockHoist                     6.170    2484     0.002
transform-property-literals             4.608    1336     0.003
transform-minify-booleans               3.899    243      0.016
minify-replace                          0.186    1        0.186
```
