### PR TITLE
Update Closure Compiler to 20160822.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "closure-compiler": "^0.2.12",
     "eslint": "~3.0.0",
     "eslint-config-babel": "^1.0.0",
-    "google-closure-compiler-js": "^20160713.0.3",
+    "google-closure-compiler-js": "^20160822.0.0",
     "gulp": "github:gulpjs/gulp#4.0",
     "gulp-babel": "^6.1.2",
     "gulp-newer": "^1.1.0",

--- a/scripts/benchmark.js
+++ b/scripts/benchmark.js
@@ -88,13 +88,14 @@ test("babili", function (code) {
 
 test("closure", function (/*code*/) {
   return child.execSync(
-    "java -jar " + path.join(__dirname, "gcc.jar") + " --jscomp_off=uselessCode --js " + filename
+    "java -jar " + path.join(__dirname, "gcc.jar") + " --env=CUSTOM --jscomp_off=* --js " + filename
   ).toString();
 });
 
 test("closure js", function (code) {
   const flags = {
-    jsCode: [{ source: code }],
+    jsCode: [{ src: code }],
+    env: "CUSTOM",
   };
   const out = compile(flags);
   return out.compiledCode;

--- a/scripts/fixtures/react.js
+++ b/scripts/fixtures/react.js
@@ -4542,7 +4542,6 @@ var ReactClassInterface = {
    *   }
    *
    * @return {ReactComponent}
-   * @nosideeffects
    * @required
    */
   render: SpecPolicy.DEFINE_ONCE,


### PR DESCRIPTION
Also update benchmark script to turn off most Closure checks and use
minimal externs. A JSDoc in react.js needs to be removed because it
currently causes an unsuppressible error in Closure.