### PR TITLE
Mangler performance - some improvement

### DIFF
--- a/packages/babel-plugin-minify-mangle-names/src/index.js
+++ b/packages/babel-plugin-minify-mangle-names/src/index.js
@@ -103,26 +103,37 @@ module.exports = ({ types: t }) => {
           //   i = 0;
           // }
 
-          Object
-            .keys(scope.getAllBindings())
-            .filter((b) => {
-              const binding = scope.getBinding(b);
+          const bindings = scope.getAllBindings();
+          const names = Object.keys(bindings);
 
-              return scope.hasOwnBinding(b)
-                && !binding.path.isLabeledStatement()
-                && !mangler.isBlacklist(b, mangler.blacklist)
-                && (mangler.keepFnames ? !isFunction(binding.path) : true);
-            })
-            .map((b) => {
-              let next;
-              do {
-                next = getNext();
-              } while (!t.isValidIdentifier(next) || scope.hasBinding(next) || scope.hasGlobal(next) || scope.hasReference(next));
-              // TODO:
-              // re-enable this
-              // resetNext();
-              mangler.rename(scope, b, next);
-            });
+          for (let i = 0; i < names.length; i++) {
+            const oldName = names[i];
+            const binding = bindings[oldName];
+
+            if (
+              !scope.hasOwnBinding(oldName)
+              || binding.path.isLabeledStatement()
+              || mangler.isBlacklist(oldName)
+              || (mangler.keepFnames ? isFunction(binding.path) : false)
+            ) {
+              continue;
+            }
+
+            let next;
+            do {
+              next = getNext();
+            } while (
+              !t.isValidIdentifier(next)
+              || scope.hasBinding(next)
+              || scope.hasGlobal(next)
+              || scope.hasReference(next)
+            );
+
+            // TODO:
+            // re-enable this - check above
+            // resetNext();
+            mangler.rename(scope, oldName, next);
+          }
         }
       });
 


### PR DESCRIPTION
This gives a ~=200ms of mangler perf. 

1. If NOT shouldConsiderSource, don't traverse Identifier & Literals for charset considerations
2. Don't recalculate hasBinding
3. loops

Most time was spent getting and verifying scope's bindings. 

The following difference is between `scope.hasBinding(next)` and `bindings.hop(next)`

```
run-mangle                 740.549  1        740.549       
scopable-loop              547.912  2222     0.247         
run-collect                370.834  1        370.834       
next-identifier            222.018  3693     0.060         
get-all-bindings           171.469  2222     0.077         
Collect-Identifier         65.521   19176    0.003         
compute-oldname            54.560   64879    0.001         
scopable-rename            49.586   3693     0.013         
rename                     42.556   3693     0.012         
```

and now after this 

```
run-mangle                 558.121  1        558.121       
scopable-loop              378.939  2222     0.171         
run-collect                369.423  1        369.423       
get-all-bindings           180.804  2222     0.081         
compute-oldname            53.859   64879    0.001         
scopable-rename            53.098   3693     0.014         
rename                     47.032   3693     0.013         
Collect-Identifier         44.661   19176    0.002         
next-identifier            39.646   3693     0.011         
```