### PR TITLE
update older packages

### DIFF
--- a/packages/babel-preset-babili/package.json
+++ b/packages/babel-preset-babili/package.json
@@ -21,12 +21,12 @@
     "babel-plugin-minify-replace": "^0.0.1",
     "babel-plugin-minify-simplify": "^0.0.1",
     "babel-plugin-minify-type-constructors": "^0.0.1",
-    "babel-plugin-transform-member-expression-literals": "^0.0.1",
-    "babel-plugin-transform-merge-sibling-variables": "^0.0.1",
-    "babel-plugin-transform-minify-booleans": "^0.0.1",
-    "babel-plugin-transform-property-literals": "^0.0.1",
-    "babel-plugin-transform-simplify-comparison-operators": "^0.0.1",
-    "babel-plugin-transform-undefined-to-void": "^0.0.1"
+    "babel-plugin-transform-member-expression-literals": "^6.8.0",
+    "babel-plugin-transform-merge-sibling-variables": "^6.8.0",
+    "babel-plugin-transform-minify-booleans": "^6.8.0",
+    "babel-plugin-transform-property-literals": "^6.8.0",
+    "babel-plugin-transform-simplify-comparison-operators": "^6.8.0",
+    "babel-plugin-transform-undefined-to-void": "^6.8.0"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
`babel-plugin-transform-` were previous packages that already were at 6.8.0

After this is merged I'm going to run lerna again in independent mode which will republish everything and I will update these to 6.8.1