### PR TITLE
Use accurate .babelrc example for minify-replace

### DIFF
--- a/packages/babel-plugin-minify-replace/README.md
+++ b/packages/babel-plugin-minify-replace/README.md
@@ -58,15 +58,19 @@ $ npm install babel-plugin-minify-replace
   "plugins": ["minify-replace"]
 }
 
-// with plugins
+// with options
 {
-  "plugins": ["minify-replace", {
-    "identifierName": "__DEV__",
-    "replacement": {
-      "type": "booleanLiteral",
-      "value": true
-    }
-  }]
+  "plugins": [
+    ["minify-replace", {
+      "replacements": [{
+        "identifierName": "__DEV__",
+        "replacement": {
+          "type": "booleanLiteral",
+          "value": true
+        }
+      }]
+    }]
+  ]
 }
 ```
 


### PR DESCRIPTION
I couldn't get the example from README.md working, so I checked the code and realized that the replacements needed to be specified on the "replacements" key of the options object.