### PR TITLE
Fix DCE for ArrayPatterns and ObjectPatterns

### DIFF
--- a/packages/babel-plugin-minify-dead-code-elimination/__tests__/dead-code-elimination-test.js
+++ b/packages/babel-plugin-minify-dead-code-elimination/__tests__/dead-code-elimination-test.js
@@ -1975,4 +1975,28 @@ describe("dce-plugin", () => {
     `);
     expect(transform(source)).toBe(expected);
   });
+
+  // https://github.com/babel/babili/issues/151
+  it("should fix issue#151 - array patterns and object patterns", () => {
+    const source = unpad(`
+      const me = lyfe => {
+        const [swag] = lyfe;
+        return swag;
+      };
+    `);
+    const expected = source;
+    expect(transform(source)).toBe(expected);
+  });
+
+  // https://github.com/babel/babili/issues/151
+  it("should fix issue#151 - array patterns and object patterns 2", () => {
+    const source = unpad(`
+      const me = lyfe => {
+        const [swag, yolo] = lyfe;
+        return swag && yolo;
+      };
+    `);
+    const expected = source;
+    expect(transform(source)).toBe(expected);
+  });
 });

--- a/packages/babel-plugin-minify-dead-code-elimination/src/index.js
+++ b/packages/babel-plugin-minify-dead-code-elimination/src/index.js
@@ -180,6 +180,11 @@ module.exports = ({ types: t, traverse }) => {
               let replacementPath = binding.path;
               if (t.isVariableDeclarator(replacement)) {
                 replacement = replacement.init;
+                // Bail out for ArrayPattern and ObjectPattern
+                // TODO: maybe a more intelligent approach instead of simply bailing out
+                if (!replacementPath.get("id").isIdentifier()) {
+                  continue;
+                }
                 replacementPath = replacementPath.get("init");
               }
               if (!replacement) {


### PR DESCRIPTION
+ Bail out for replacement of single use variable inside a function

TODO (for later): maybe a more intelligent approach to replace - for ex,

```js
// from
const [a] = b; return a;
const {a} = b; return a;

// to
return b[0];
return b.a;
```
+ (Close #151)