### PR TITLE
don't merge block-scoped sibling vars across scopes, fix #153

### DIFF
--- a/packages/babel-plugin-transform-merge-sibling-variables/__tests__/transform-merge-sibling-variables-test.js
+++ b/packages/babel-plugin-transform-merge-sibling-variables/__tests__/transform-merge-sibling-variables-test.js
@@ -36,4 +36,38 @@ describe("transform-merge-sibling-variables-plugin", () => {
 
     expect(transform(source).trim()).toBe(expected);
   });
+
+  it("don't concat block-scoped variables in for loops", () => {
+    const source = unpad(`
+      let i = 0;
+      for (let x = 0; x < 10; x++) console.log(i + x);
+    `);
+
+    expect(transform(source)).toBe(source);
+  });
+
+  it("don't concat constants in for loops", () => {
+    const source = unpad(`
+      const j = 0;
+      for (const x = 0;;) console.log(j + x);
+    `);
+
+    expect(transform(source)).toBe(source);
+  });
+
+  it("concat block-scoped vars next to, but not into for loops", () => {
+    const source = unpad(`
+      let i = 0;
+      let y = 0;
+      for (let x = 0; x < 10; x++) console.log(i + x);
+    `);
+    const expected = unpad(`
+      let i = 0,
+          y = 0;
+
+      for (let x = 0; x < 10; x++) console.log(i + x);
+    `);
+
+    expect(transform(source)).toBe(expected);
+  });
 });

--- a/packages/babel-plugin-transform-merge-sibling-variables/src/index.js
+++ b/packages/babel-plugin-transform-merge-sibling-variables/src/index.js
@@ -25,14 +25,19 @@ module.exports = function() {
             }
           },
 
-          // concat variable declarations next to for loops with it's
-          // initialisers if they're of the same variable kind
+          // concat `var` declarations next to for loops with it's initialisers.
+          // block-scoped `let` and `const` are not moved because the for loop
+          // is a different block scope.
           function (path) {
             if (!path.inList) {
               return;
             }
 
             const { node } = path;
+            if (node.kind !== "var") {
+              return;
+            }
+
             let next = path.getSibling(path.key + 1);
             if (!next.isForStatement()) {
               return;


### PR DESCRIPTION
Only move `var` declarations into `for` loop initialisers, so `let` and `const`
declarations are still available outside the loop.