### PR TITLE
don't remove impure reachable parts of logical expressions

### DIFF
--- a/packages/babel-plugin-minify-guarded-expressions/__tests__/guarded-expressions-test.js
+++ b/packages/babel-plugin-minify-guarded-expressions/__tests__/guarded-expressions-test.js
@@ -71,11 +71,58 @@ describe("guarded-expressions-plugin", () => {
       alert("");
     `);
     expect(transform(source)).toBe(expected);
+
+    source = unpad(`
+      alert(new Foo() || false);
+    `);
+    expected = unpad(`
+      alert(new Foo());
+    `);
+    expect(transform(source)).toBe(expected);
   });
 
-  it("should not remove unpure statements that always evaluate to false", () => {
-    const source = unpad(`
+  it("should simplify truthy expressions", () => {
+    let source = unpad(`
+      alert(1 && new Bar());
+    `);
+    let expected = unpad(`
+      alert(new Bar());
+    `);
+    expect(transform(source)).toBe(expected);
+
+    source = unpad(`
+      alert(true && new Bar());
+    `);
+    expected = unpad(`
+      alert(new Bar());
+    `);
+    expect(transform(source)).toBe(expected);
+
+    source = unpad(`
+      alert("hello" && new Bar());
+    `);
+    expected = unpad(`
+      alert(new Bar());
+    `);
+    expect(transform(source)).toBe(expected);
+
+    source = unpad(`
+      alert(!false && new Bar());
+    `);
+    expected = unpad(`
+      alert(new Bar());
+    `);
+    expect(transform(source)).toBe(expected);
+  });
+
+  it("should not remove reachable impure statements", () => {
+    let source = unpad(`
       a && void alert('Side effect');
+    `);
+    expect(transform(source)).toBe(source);
+
+    source = unpad(`
+      alert(func() || true);
     `);
     expect(transform(source)).toBe(source);
   });

--- a/packages/babel-plugin-minify-guarded-expressions/__tests__/guarded-expressions-test.js
+++ b/packages/babel-plugin-minify-guarded-expressions/__tests__/guarded-expressions-test.js
@@ -72,4 +72,11 @@ describe("guarded-expressions-plugin", () => {
     `);
     expect(transform(source)).toBe(expected);
   });
+
+  it("should not remove unpure statements that always evaluate to false", () => {
+    const source = unpad(`
+      a && void alert('Side effect');
+    `);
+    expect(transform(source)).toBe(source);
+  });
 });

--- a/packages/babel-plugin-minify-guarded-expressions/src/index.js
+++ b/packages/babel-plugin-minify-guarded-expressions/src/index.js
@@ -15,8 +15,17 @@ module.exports = function({ types: t }) {
           function(path) {
             const { node } = path;
 
-            if (path.evaluateTruthy(node) === false) {
-              path.replaceWith(node.left);
+            const left = path.get("left");
+            const right = path.get("right");
+            if (node.operator === "&&") {
+              if ((right.evaluateTruthy() === false && right.isPure()) ||
+                  (left.evaluateTruthy() === false && left.isPure())) {
+                path.replaceWith(node.left);
+              }
+            } else if (node.operator === "||") {
+              if (left.evaluateTruthy() === false && left.isPure()) {
+                path.replaceWith(node.left);
+              }
             }
           },
 

--- a/packages/babel-plugin-minify-guarded-expressions/src/index.js
+++ b/packages/babel-plugin-minify-guarded-expressions/src/index.js
@@ -18,12 +18,18 @@ module.exports = function({ types: t }) {
             const left = path.get("left");
             const right = path.get("right");
             if (node.operator === "&&") {
-              if ((right.evaluateTruthy() === false && right.isPure()) ||
-                  (left.evaluateTruthy() === false && left.isPure())) {
+              const leftTruthy = left.evaluateTruthy();
+              if (leftTruthy === false) {
+                path.replaceWith(node.left);
+              } else if (leftTruthy === true && left.isPure()) {
+                path.replaceWith(node.right);
+              } else if (right.evaluateTruthy() === false && right.isPure()) {
                 path.replaceWith(node.left);
               }
             } else if (node.operator === "||") {
               if (left.evaluateTruthy() === false && left.isPure()) {
+                path.replaceWith(node.right);
+              } else if (left.evaluateTruthy() === true) {
                 path.replaceWith(node.left);
               }
             }

--- a/packages/babel-plugin-minify-guarded-expressions/src/index.js
+++ b/packages/babel-plugin-minify-guarded-expressions/src/index.js
@@ -20,6 +20,7 @@ module.exports = function({ types: t }) {
             if (node.operator === "&&") {
               const leftTruthy = left.evaluateTruthy();
               if (leftTruthy === false) {
+                // Short-circuit
                 path.replaceWith(node.left);
               } else if (leftTruthy === true && left.isPure()) {
                 path.replaceWith(node.right);
@@ -27,9 +28,13 @@ module.exports = function({ types: t }) {
                 path.replaceWith(node.left);
               }
             } else if (node.operator === "||") {
-              if (left.evaluateTruthy() === false && left.isPure()) {
+              const leftTruthy = left.evaluateTruthy();
+              if (leftTruthy === false && left.isPure()) {
                 path.replaceWith(node.right);
-              } else if (left.evaluateTruthy() === true) {
+              } else if (leftTruthy === true) {
+                // Short-circuit
+                path.replaceWith(node.left);
+              } else if (right.evaluateTruthy() === false && right.isPure()) {
                 path.replaceWith(node.left);
               }
             }


### PR DESCRIPTION
An attempt at dealing with #159.

Impure statements like function calls were removed from the right-hand side of `&&` expressions if they were inferred to return a falsy value (e.g. when using the `void` operator).

This patch checks if the thing to be removed is pure. There's a lot more manual checking involved but it also simplifies more stuff.