### PR TITLE
[DCE] Fix var hoisting

### DIFF
--- a/packages/babel-plugin-minify-dead-code-elimination/__tests__/dead-code-elimination-test.js
+++ b/packages/babel-plugin-minify-dead-code-elimination/__tests__/dead-code-elimination-test.js
@@ -1999,4 +1999,39 @@ describe("dce-plugin", () => {
     const expected = source;
     expect(transform(source)).toBe(expected);
   });
+
+  it("should preserve variabledeclarations(var) after completion statements", () => {
+    const source = unpad(`
+      function foo() {
+        a = 1;
+        return a;
+        var a;
+      }
+    `);
+
+    const expected = source;
+
+    expect(transform(source)).toBe(expected);
+  });
+
+  it("should NOT preserve variabledeclarations(let) after completion statements", () => {
+    const source = unpad(`
+      function foo() {
+        a = 1;
+        b = 2;
+        return a + b;
+        let a, b;
+      }
+    `);
+
+    const expected = unpad(`
+      function foo() {
+        a = 1;
+        b = 2;
+        return a + b;
+      }
+    `);
+
+    expect(transform(source)).toBe(expected);
+  });
 });

--- a/packages/babel-plugin-minify-dead-code-elimination/src/index.js
+++ b/packages/babel-plugin-minify-dead-code-elimination/src/index.js
@@ -283,7 +283,7 @@ module.exports = ({ types: t, traverse }) => {
           continue;
         }
 
-        if (purge && !p.isFunctionDeclaration()) {
+        if (purge && !canExistAfterCompletion(p)) {
           removeOrVoid(p);
         }
       }
@@ -299,7 +299,7 @@ module.exports = ({ types: t, traverse }) => {
 
       // Not last in it's block? (See BlockStatement visitor)
       if (path.container.length - 1 !== path.key &&
-          !path.getSibling(path.key + 1).isFunctionDeclaration() &&
+          !canExistAfterCompletion(path.getSibling(path.key + 1)) &&
           path.parentPath.isBlockStatement()
       ) {
         // This is probably a new oppurtinity by some other transform
@@ -899,5 +899,11 @@ module.exports = ({ types: t, traverse }) => {
         bail: possibleRunTimeBreak
       };
     }
+  }
+
+  // things that are hoisted
+  function canExistAfterCompletion(path) {
+    return path.isFunctionDeclaration()
+      || path.isVariableDeclaration({ kind: "var" });
   }
 };


### PR DESCRIPTION
+ (Close #167)

One other option to handle this will be to hoist var declarations as one of the first plugins. But @amasad had concerns with the hoisting effect on gzip in #52 . So this approach is okay IMO. 

`a = 1; return a; var a;` could not be reduced to `return 1` because we don't have the flow of control in the program - this is here in babel - https://github.com/babel/babel/issues/4420