### PR TITLE
minify-dead-code-elimination: remove dead logical expressions

### DIFF
--- a/packages/babel-plugin-minify-dead-code-elimination/__tests__/dead-code-elimination-test.js
+++ b/packages/babel-plugin-minify-dead-code-elimination/__tests__/dead-code-elimination-test.js
@@ -2034,4 +2034,18 @@ describe("dce-plugin", () => {
 
     expect(transform(source)).toBe(expected);
   });
+
+  it("should remove dead logical expressions", () => {
+    const source = unpad(`
+      false && foo();
+      true && bar();
+      x && true && foo();  
+    `);
+    const expected = unpad(` 
+      false;
+      bar();
+      x && foo();
+    `);
+    expect(transform(source).trim()).toBe(expected);
+  });
 });

--- a/packages/babel-plugin-minify-dead-code-elimination/src/index.js
+++ b/packages/babel-plugin-minify-dead-code-elimination/src/index.js
@@ -620,6 +620,30 @@ module.exports = ({ types: t, traverse }) => {
       path.node.left = t.variableDeclaration("var", [t.variableDeclarator(left.node)]);
       binding.path = path.get("left").get("declarations")[0];
     },
+
+    LogicalExpression: {
+      exit(path) {
+        const evaluated = path.evaluate();
+        if (evaluated.confident) {
+          path.replaceWith(t.valueToNode(evaluated.value));
+          return;
+        }
+
+        const node = path.node;
+        if (node.operator !== "&&") return;
+
+        const leftTruthy = path.get("left").evaluateTruthy();
+        if (leftTruthy === true) {
+          path.replaceWith(node.right);
+          return;
+        }
+
+        const rightTruthy = path.get("right").evaluateTruthy();
+        if (rightTruthy === true) {
+          path.replaceWith(node.left);
+        }
+      },
+    },
   };
 
   return {

--- a/packages/babel-plugin-minify-dead-code-elimination/src/index.js
+++ b/packages/babel-plugin-minify-dead-code-elimination/src/index.js
@@ -623,24 +623,16 @@ module.exports = ({ types: t, traverse }) => {
 
     LogicalExpression: {
       exit(path) {
-        const evaluated = path.evaluate();
-        if (evaluated.confident) {
-          path.replaceWith(t.valueToNode(evaluated.value));
-          return;
-        }
-
         const node = path.node;
-        if (node.operator !== "&&") return;
-
-        const leftTruthy = path.get("left").evaluateTruthy();
-        if (leftTruthy === true) {
-          path.replaceWith(node.right);
-          return;
-        }
-
-        const rightTruthy = path.get("right").evaluateTruthy();
-        if (rightTruthy === true) {
-          path.replaceWith(node.left);
+        if (node.operator === "&&" || node.operator === "||") {
+          const leftEvaluated = path.get("left").evaluate();
+          if (leftEvaluated.confident) {
+            if (node.operator === "&&") {
+              path.replaceWith(leftEvaluated.value ? node.right : t.valueToNode(leftEvaluated.value));
+            } else {
+              path.replaceWith(leftEvaluated.value ? t.valueToNode(leftEvaluated.value) : node.right);
+            }
+          }
         }
       },
     },


### PR DESCRIPTION
Transforms:

```js
false && foo();
true && bar();
```

into:

```js
false;
bar();
```