### PR TITLE
Mangle - Fix label shadowing

### DIFF
--- a/packages/babel-plugin-minify-mangle-names/__tests__/mangle-names-test.js
+++ b/packages/babel-plugin-minify-mangle-names/__tests__/mangle-names-test.js
@@ -177,7 +177,7 @@ describe("mangle-names", () => {
   });
 
   // https://phabricator.babeljs.io/T6957
-  xit("labels should not shadow bindings", () => {
+  it("labels should not shadow bindings", () => {
     const source = unpad(`
       function foo() {
         var meh;
@@ -195,6 +195,31 @@ describe("mangle-names", () => {
           break meh;
         }
         return a;
+      }
+    `);
+
+    expect(transform(source)).toBe(expected);
+  });
+
+  // https://github.com/babel/babili/issues/185
+  it("labels should not shadow bindings 2", () => {
+    const source = unpad(`
+      function f(a) {
+        try {
+          a: {
+            console.log(a);
+          }
+        } catch ($a) {}
+      }
+    `);
+
+    const expected = unpad(`
+      function f(b) {
+        try {
+          a: {
+            console.log(b);
+          }
+        } catch (c) {}
       }
     `);
 

--- a/packages/babel-plugin-minify-mangle-names/src/index.js
+++ b/packages/babel-plugin-minify-mangle-names/src/index.js
@@ -89,10 +89,10 @@ module.exports = ({ types: t }) => {
             const binding = bindings[oldName];
 
             if (binding.path.isLabeledStatement()) {
-              const faulty = binding.referencePaths.filter(ref => {
+              const faulty = binding.referencePaths.filter((ref) => {
                 return !(ref.parentPath.isBreakStatement() || ref.parentPath.isContinueStatement());
               });
-              faulty.forEach(f => {
+              faulty.forEach((f) => {
                 const index = binding.referencePaths.indexOf(f);
                 if (index > -1) {
                   binding.referencePaths.splice(index, 1);
@@ -105,13 +105,13 @@ module.exports = ({ types: t }) => {
 
               scope.removeBinding(oldName);
               const newBinding = scope.getBinding(oldName);
-              faulty.forEach(f => newBinding.reference(f));
+              faulty.forEach((f) => newBinding.reference(f));
 
               continue;
             }
           }
         }
-      })
+      });
 
       this.program.traverse({
         Scopable(path) {


### PR DESCRIPTION
+ (Close #185) 

Not sure if there are any other bugs that this will lead to. If so, afaik, it will only lead to LabelStatement bugs.

+ Adds a 250-300ms to mangler because of the double pass. Maybe we can add a flag to `useLabels` - maybe ? and when babel starts treating Labels in a separate namespace, we can remove the code - incase we merge this...
+ this needs traversing program twice because the second time, the vars get replaced from outer scope and we cannot bind the referencedIdentifier to its BindingIdentifier - as we check this based on the Identifier name