### PR TITLE
Integrated babel-plugin-transform-regexp-constructors into preset.

### DIFF
--- a/packages/babel-plugin-transform-regexp-constructors/README.md
+++ b/packages/babel-plugin-transform-regexp-constructors/README.md
@@ -1,7 +1,6 @@
 # babel-plugin-transform-regexp-constructors
 
-This changes RegExp constructors into literals if and only if the RegExp
-arguments are string literals.
+This changes RegExp constructors into literals if the RegExp arguments are strings.
 
 ## Example
 

--- a/packages/babel-plugin-transform-regexp-constructors/package.json
+++ b/packages/babel-plugin-transform-regexp-constructors/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "babel-plugin-transform-regexp-constructors",
+  "version": "0.0.1",
+  "description": "This changes RegExp constructors into literals if the RegExp arguments are strings.",
+  "homepage": "https://github.com/babel/babili#readme",
+  "repository": "https://github.com/babel/babili/tree/master/packages/babel-plugin-transform-regexp-constructors",
+  "bugs": "https://github.com/babel/babili/issues",
+  "author": "shinew",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "keywords": [
+    "babel-plugin"
+  ],
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/packages/babel-preset-babili/package.json
+++ b/packages/babel-preset-babili/package.json
@@ -26,7 +26,8 @@
     "babel-plugin-transform-minify-booleans": "^6.8.0",
     "babel-plugin-transform-property-literals": "^6.8.0",
     "babel-plugin-transform-simplify-comparison-operators": "^6.8.0",
-    "babel-plugin-transform-undefined-to-void": "^6.8.0"
+    "babel-plugin-transform-undefined-to-void": "^6.8.0",
+    "babel-plugin-transform-regexp-constructors": "^0.0.1"
   },
   "devDependencies": {}
 }

--- a/packages/babel-preset-babili/package.json
+++ b/packages/babel-preset-babili/package.json
@@ -25,9 +25,9 @@
     "babel-plugin-transform-merge-sibling-variables": "^6.8.0",
     "babel-plugin-transform-minify-booleans": "^6.8.0",
     "babel-plugin-transform-property-literals": "^6.8.0",
+    "babel-plugin-transform-regexp-constructors": "^0.0.1",
     "babel-plugin-transform-simplify-comparison-operators": "^6.8.0",
-    "babel-plugin-transform-undefined-to-void": "^6.8.0",
-    "babel-plugin-transform-regexp-constructors": "^0.0.1"
+    "babel-plugin-transform-undefined-to-void": "^6.8.0"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
Follow-up to https://github.com/babel/babili/pull/196.