### PR TITLE
Implemented babel-plugin-remove-unused-params.

### DIFF
--- a/packages/babel-plugin-remove-unused-params/README.md
+++ b/packages/babel-plugin-remove-unused-params/README.md
@@ -1,0 +1,53 @@
+# babel-plugin-remove-unused-params
+
+This plugin removes unused trailing function parameters.
+
+## Example
+
+**In**
+
+```javascript
+function foo(a, b) {
+  return a;
+}
+```
+
+**Out**
+
+```javascript
+function foo(a) {
+  return a;
+}
+```
+
+## Installation
+
+```sh
+$ npm install babel-plugin-remove-unused-params
+```
+
+## Usage
+
+### Via `.babelrc` (Recommended)
+
+**.babelrc**
+
+```json
+{
+  "plugins": ["remove-unused-params"]
+}
+```
+
+### Via CLI
+
+```sh
+$ babel --plugins remove-unused-params script.js
+```
+
+### Via Node API
+
+```javascript
+require("babel-core").transform("code", {
+  plugins: ["remove-unused-params"]
+});
+```

--- a/packages/babel-plugin-remove-unused-params/__tests__/babel-plugin-remove-unused-params-test.js
+++ b/packages/babel-plugin-remove-unused-params/__tests__/babel-plugin-remove-unused-params-test.js
@@ -1,0 +1,91 @@
+jest.autoMockOff();
+
+const babel = require("babel-core");
+const plugin = require("../src/index");
+
+function transform(code) {
+  return babel.transform(code,  {
+    plugins: [plugin],
+  }).code;
+}
+
+describe("remove-unused-params-plugin", () => {
+  it("should remove trailing unused params", () => {
+    const source =
+`function foo(a, b, c) {
+  return a;
+}`;
+    const expected =
+`function foo(a) {
+  return a;
+}`;
+    expect(transform(source)).toBe(expected);
+  });
+
+  it("should preserve unused params before used params", () => {
+    const source =
+`function foo(a, b, c) {
+  return b;
+}`;
+    const expected =
+`function foo(a, b) {
+  return b;
+}`;
+    expect(transform(source)).toBe(expected);
+  });
+
+  it("should remove all params if all unused", () => {
+    const source =
+`function foo(a, b, c) {
+  return 42;
+}`;
+    const expected =
+`function foo() {
+  return 42;
+}`;
+    expect(transform(source)).toBe(expected);
+  });
+
+
+  it("should remove all params if all unused", () => {
+    const source =
+`function foo(a, b, c) {
+  return 42;
+}`;
+    const expected =
+`function foo() {
+  return 42;
+}`;
+    expect(transform(source)).toBe(expected);
+  });
+
+  it("should not remove params if referenced in nested functions", () => {
+    const source =
+`function foo(a, b, c) {
+  function bar(c = b()) {
+    return;
+  }
+  return 42;
+}`;
+    const expected =
+`function foo(a, b) {
+  function bar(c = b()) {
+    return;
+  }
+  return 42;
+}`;
+    expect(transform(source)).toBe(expected);
+  });
+
+  it("should not remove nested params if referenced", () => {
+    const source =
+`function foo({ a: aa, b: bb }, [c, d]) {
+  return aa;
+}`;
+    const expected =
+`function foo({ a: aa, b: bb }) {
+  return aa;
+}`;
+    expect(transform(source)).toBe(expected);
+  });
+});

--- a/packages/babel-plugin-remove-unused-params/package.json
+++ b/packages/babel-plugin-remove-unused-params/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "babel-plugin-remove-unused-params",
+  "version": "0.0.1",
+  "description": "This plugin removes unused trailing function parameters.",
+  "homepage": "https://github.com/babel/babili#readme",
+  "repository": "https://github.com/babel/babili/tree/master/packages/babel-plugin-remove-unused-params",
+  "bugs": "https://github.com/babel/babili/issues",
+  "author": "shinew",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "keywords": [
+    "babel-plugin"
+  ],
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/packages/babel-plugin-remove-unused-params/src/index.js
+++ b/packages/babel-plugin-remove-unused-params/src/index.js
@@ -1,0 +1,43 @@
+"use strict";
+
+function isIdentifierReferenced(id, scope) {
+  const binding = scope.getBinding(id.node.name);
+  if (!binding) {
+    return false;
+  }
+  return binding.references > 0;
+}
+
+function isLvalReferenced(lval, scope, t) {
+  if (t.isIdentifier(lval)) {
+    return isIdentifierReferenced(lval, scope);
+  }
+  let isAnyIdReferenced = false;
+  lval.traverse({
+    Identifier(path) {
+      if (isIdentifierReferenced(path, scope)) {
+        isAnyIdReferenced = true;
+      }
+    }
+  });
+  return isAnyIdReferenced;
+}
+
+module.exports = function({ types: t }) {
+  return {
+    name: "remove-unused-params",
+    visitor: {
+      Function(path) {
+        const lvals = path.get("params");
+        const isReferenced = lvals.map(
+          (lval) => isLvalReferenced(lval, path.scope, t));
+        for (let i = lvals.length - 1; i >= 0; i--) {
+          if (isReferenced[i] === true) {
+            break;
+          }
+          lvals[i].remove();
+        }
+      },
+    },
+  };
+};


### PR DESCRIPTION
Removes unused trailing params for functions.

Note: not safe because it changes `length` as noted in https://github.com/babel/babili/issues/25.