### PR TITLE
Inline temp return

### DIFF
--- a/packages/babel-plugin-transform-inline-temp-return/.npmignore
+++ b/packages/babel-plugin-transform-inline-temp-return/.npmignore
@@ -1,0 +1,4 @@
+src
+__tests__
+node_modules
+*.log

--- a/packages/babel-plugin-transform-inline-temp-return/README.md
+++ b/packages/babel-plugin-transform-inline-temp-return/README.md
@@ -1,0 +1,55 @@
+# babel-plugin-transform-inline-temp-return
+
+This removes the temporary variable right before return statements, if it is
+also the return value.
+
+## Example
+
+**In**
+
+```javascript
+function foo() {
+  let a = bar();
+  return a;
+}
+```
+
+**Out**
+
+```javascript
+function foo() {
+  return bar();
+}
+```
+
+## Installation
+
+```sh
+$ npm install babel-plugin-transform-inline-temp-return
+```
+
+## Usage
+
+### Via `.babelrc` (Recommended)
+
+**.babelrc**
+
+```json
+{
+  "plugins": ["transform-inline-temp-return"]
+}
+```
+
+### Via CLI
+
+```sh
+$ babel --plugins transform-inline-temp-return script.js
+```
+
+### Via Node API
+
+```javascript
+require("babel-core").transform("code", {
+  plugins: ["transform-inline-temp-return"]
+});
+```

--- a/packages/babel-plugin-transform-inline-temp-return/__tests__/inline-temp-return-test.js
+++ b/packages/babel-plugin-transform-inline-temp-return/__tests__/inline-temp-return-test.js
@@ -1,0 +1,56 @@
+jest.autoMockOff();
+
+const babel = require("babel-core");
+const plugin = require("../src/index");
+const unpad = require("../../../utils/unpad");
+
+function transform(code) {
+  return babel.transform(code,  {
+    plugins: [plugin],
+  }).code;
+}
+
+describe("transform-inline-temp-plugin", () => {
+  it("should inline temp variable", () => {
+    const source = unpad(`
+      function foo() {
+        let a = bar();
+        return a;
+      }
+    `);
+    const expected = unpad(`
+      function foo() {
+        return bar();
+      }
+    `);
+    expect(transform(source)).toBe(expected);
+  });
+
+  it("should inline temp variable in all blocks", () => {
+    const source = unpad(`
+      function foo() {
+        if (something) {
+          let a = bar();
+          return a;
+        } else {
+          const c = what();
+          return c;
+        }
+        var s = ok();
+        return s;
+      }
+    `);
+    const expected = unpad(`
+      function foo() {
+        if (something) {
+          return bar();
+        } else {
+          return what();
+        }
+
+        return ok();
+      }
+    `);
+    expect(transform(source)).toBe(expected);
+  });
+});

--- a/packages/babel-plugin-transform-inline-temp-return/package.json
+++ b/packages/babel-plugin-transform-inline-temp-return/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "babel-plugin-transform-inline-temp-return",
+  "version": "0.0.1",
+  "description": "This removes the temporary variable right before return statements, if it is also the return value.",
+  "homepage": "https://github.com/babel/babili#readme",
+  "repository": "https://github.com/babel/babili/tree/master/packages/babel-plugin-transform-inline-temp-return",
+  "bugs": "https://github.com/babel/babili/issues",
+  "author": "shinew",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "keywords": [
+    "babel-plugin"
+  ],
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/packages/babel-plugin-transform-inline-temp-return/src/index.js
+++ b/packages/babel-plugin-transform-inline-temp-return/src/index.js
@@ -28,7 +28,7 @@ function isSafeToInline(i, statements, scope, t) {
   return true;
 }
 
-function inline(i, block, statements, t) {
+function inline(i, block, statements) {
   const varDeclaration = statements[i - 1];
   const exp = varDeclaration.declarations[0].init;
   const statementsPath = block.get("body");

--- a/packages/babel-plugin-transform-inline-temp-return/src/index.js
+++ b/packages/babel-plugin-transform-inline-temp-return/src/index.js
@@ -1,0 +1,53 @@
+"use strict";
+
+function isSafeToInline(i, statements, scope, t) {
+  if (!t.isReturnStatement(statements[i])) {
+    return false;
+  }
+  const returnStatement = statements[i];
+  if (!t.isIdentifier(returnStatement.argument)) {
+    return false;
+  }
+  if (i === 0) {
+    return false;
+  }
+  const varDeclaration = statements[i - 1];
+  if (!(t.isVariableDeclaration(varDeclaration) &&
+      varDeclaration.declarations.length === 1 &&
+      t.isIdentifier(varDeclaration.declarations[0].id))) {
+    return false;
+  }
+  const id = varDeclaration.declarations[0].id;
+  const binding = scope.getOwnBinding(id.name);
+  if (binding.references !== 1) {
+    return false;
+  }
+  if (returnStatement.argument.name !== id.name) {
+    return false;
+  }
+  return true;
+}
+
+function inline(i, block, statements, t) {
+  const varDeclaration = statements[i - 1];
+  const exp = varDeclaration.declarations[0].init;
+  const statementsPath = block.get("body");
+  statementsPath[i].get("argument").replaceWith(exp);
+  statementsPath[i - 1].remove();
+}
+
+module.exports = function({ types: t }) {
+  return {
+    name: "transform-inline-temp-return",
+    visitor: {
+      BlockStatement(path) {
+        const statements = path.node.body;
+        for (let i = 0; i < statements.length; i++) {
+          if (isSafeToInline(i, statements, path.scope, t)) {
+            inline(i, path, statements, t);
+          }
+        }
+      },
+    },
+  };
+};


### PR DESCRIPTION
This removes the temporary variable right before return statements, if it is also the return value.