### PR TITLE
Require blocks around single block-scope declaration

### DIFF
--- a/packages/babel-plugin-minify-simplify/__tests__/simplify-test.js
+++ b/packages/babel-plugin-minify-simplify/__tests__/simplify-test.js
@@ -2127,8 +2127,10 @@ describe("simplify-plugin", () => {
     const source = unpad(`
       if (false) {
         let { a } = foo();
-      } else {
+      } else if (true) {
         const x = bar();
+      } else {
+        function baz() {}
       }
     `);
     const expected = source;

--- a/packages/babel-plugin-minify-simplify/__tests__/simplify-test.js
+++ b/packages/babel-plugin-minify-simplify/__tests__/simplify-test.js
@@ -2122,4 +2122,16 @@ describe("simplify-plugin", () => {
     `);
     expect(transform(source)).toBe(expected);
   });
+
+  it("should require block for single block scoped declaration in if/else", () => {
+    const source = unpad(`
+      if (false) {
+        let { a } = foo();
+      } else {
+        const x = bar();
+      }
+    `);
+    const expected = source;
+    expect(transform(source)).toBe(expected);
+  });
 });

--- a/packages/babel-plugin-minify-simplify/src/index.js
+++ b/packages/babel-plugin-minify-simplify/src/index.js
@@ -1232,7 +1232,8 @@ module.exports = ({ types: t }) => {
       block.body.length === 1 &&
       (
         t.isVariableDeclaration(block.body[0], { kind: "let" }) ||
-        t.isVariableDeclaration(block.body[0], { kind: "const" })
+        t.isVariableDeclaration(block.body[0], { kind: "const" }) ||
+        t.isFunctionDeclaration(block.body[0])
       );
   }
 

--- a/packages/babel-plugin-minify-simplify/src/index.js
+++ b/packages/babel-plugin-minify-simplify/src/index.js
@@ -1223,7 +1223,17 @@ module.exports = ({ types: t }) => {
   function needsBlock(node, parent) {
     return (t.isFunction(parent) && node === parent.body) ||
            t.isTryStatement(parent) || t.isCatchClause(parent) ||
-           t.isSwitchStatement(parent);
+           t.isSwitchStatement(parent) ||
+           (isSingleBlockScopeDeclaration(node) && t.isIfStatement(parent));
+  }
+
+  function isSingleBlockScopeDeclaration(block) {
+    return t.isBlockStatement(block) &&
+      block.body.length === 1 &&
+      (
+        t.isVariableDeclaration(block.body[0], { kind: "let" }) ||
+        t.isVariableDeclaration(block.body[0], { kind: "const" })
+      );
   }
 
   function isVoid0(expr) {


### PR DESCRIPTION
+ (close #213)

The var declaration removal should be done in DCE instead of simplify. This is necessary as simplify as a standalone plugin should not produce syntax errors. 