### PR TITLE
Reuse removed vars in mangler

### DIFF
--- a/packages/babel-plugin-minify-mangle-names/__tests__/mangle-names-reuse-test.js
+++ b/packages/babel-plugin-minify-mangle-names/__tests__/mangle-names-reuse-test.js
@@ -1131,4 +1131,22 @@ describe("mangle-names", () => {
     `);
     expect(transformWithSimplify(source)).toBe(expected);
   });
+
+  it("should work with object destructuring", () => {
+    const source = unpad(`
+      function a() {
+        let foo, bar, baz;
+        ({foo, bar, baz} = {});
+        return {foo, bar, baz};
+      }
+    `);
+    const expected = unpad(`
+      function a() {
+        let a, b, c;
+        ({ foo: a, bar: b, baz: c } = {});
+        return { foo: a, bar: b, baz: c };
+      }
+    `);
+    expect(transform(source)).toBe(expected);
+  });
 });

--- a/packages/babel-plugin-minify-mangle-names/__tests__/mangle-names-reuse-test.js
+++ b/packages/babel-plugin-minify-mangle-names/__tests__/mangle-names-reuse-test.js
@@ -768,11 +768,9 @@ describe("mangle-names", () => {
     expect(actual).toBe(expected);
   });
 
-  it("should NOT mangle functions & classes when keepFnName is true", () => {
+  it("should NOT mangle functions when keepFnName is true", () => {
     const source = unpad(`
       (function() {
-        class Foo {}
-        const Bar = class Bar extends Foo {}
         var foo = function foo() {
           foo();
         }
@@ -786,20 +784,44 @@ describe("mangle-names", () => {
     `);
     const expected = unpad(`
       (function () {
-        class Foo {}
-        const a = class Bar extends Foo {};
-        var b = function foo() {
+        var a = function foo() {
           foo();
         };
         function bar() {
-          b();
+          a();
         }
         bar();
-        var c = b;
-        c();
+        var b = a;
+        b();
       })();
     `);
     expect(transform(source, {keepFnName: true})).toBe(expected);
+  });
+
+  it("should NOT mangle classes when keepClassName is true", () => {
+    const source = unpad(`
+      (function() {
+        class Foo {}
+        const Bar = class Bar extends Foo {}
+        var foo = class Baz {}
+        function bar() {
+          new foo();
+        }
+        bar();
+      })();
+    `);
+    const expected = unpad(`
+      (function () {
+        class Foo {}
+        const b = class Bar extends Foo {};
+        var c = class Baz {};
+        function a() {
+          new c();
+        }
+        a();
+      })();
+    `);
+    expect(transform(source, {keepClassName: true})).toBe(expected);
   });
 
   it("should mangle variable re-declaration / K violations", () => {

--- a/packages/babel-plugin-minify-mangle-names/__tests__/mangle-names-test.js
+++ b/packages/babel-plugin-minify-mangle-names/__tests__/mangle-names-test.js
@@ -5,6 +5,7 @@ const babel    = require("babel-core");
 const unpad    = require("../../../utils/unpad");
 
 function transform(code, options = {}, sourceType = "script") {
+  options.reuse = false;
   return babel.transform(code,  {
     sourceType,
     plugins: [
@@ -14,6 +15,7 @@ function transform(code, options = {}, sourceType = "script") {
 }
 
 function transformWithSimplify(code, options = {}, sourceType = "script") {
+  options.reuse = false;
   return babel.transform(code, {
     sourceType,
     plugins: [
@@ -595,7 +597,7 @@ describe("mangle-names", () => {
     traverse.clearCache();
 
     const actual = babel.transformFromAst(first.ast, null, {
-      plugins: [require("../src/index")],
+      plugins: [[require("../src/index"), { reuse: false }]],
     }).code;
 
     const expected = unpad(`
@@ -643,7 +645,7 @@ describe("mangle-names", () => {
     traverse.clearCache();
 
     const actual = babel.transformFromAst(first.ast, null, {
-      plugins: [require("../src/index")],
+      plugins: [[require("../src/index"), { reuse: false }]],
     }).code;
 
     const expected = unpad(`

--- a/packages/babel-plugin-minify-mangle-names/__tests__/mangle-names-test.js
+++ b/packages/babel-plugin-minify-mangle-names/__tests__/mangle-names-test.js
@@ -1089,5 +1089,22 @@ describe("mangle-names", () => {
     `);
     expect(transformWithSimplify(source)).toBe(expected);
   });
-});
 
+  it("should work with object destructuring", () => {
+    const source = unpad(`
+      function a() {
+        let foo, bar, baz;
+        ({foo, bar, baz} = {});
+        return {foo, bar, baz};
+      }
+    `);
+    const expected = unpad(`
+      function a() {
+        let b, c, d;
+        ({ foo: b, bar: c, baz: d } = {});
+        return { foo: b, bar: c, baz: d };
+      }
+    `);
+    expect(transform(source)).toBe(expected);
+  });
+});

--- a/packages/babel-plugin-minify-mangle-names/src/counted-set.js
+++ b/packages/babel-plugin-minify-mangle-names/src/counted-set.js
@@ -1,0 +1,28 @@
+// Set that counts
+module.exports = class CountedSet {
+  constructor() {
+    // because you can't simply extend Builtins yet
+    this.map = new Map;
+  }
+  keys() {
+    return [...this.map.keys()];
+  }
+  has(value) {
+    return this.map.has(value);
+  }
+  add(value) {
+    if (!this.has(value)) {
+      this.map.set(value, 0);
+    }
+    this.map.set(value, this.map.get(value) + 1);
+  }
+  delete(value) {
+    if (!this.has(value)) return;
+    const count = this.map.get(value);
+    if (count <= 1) {
+      this.map.delete(value);
+    } else {
+      this.map.set(value, count - 1);
+    }
+  }
+};

--- a/packages/babel-plugin-minify-mangle-names/src/get-binding-identifiers.js
+++ b/packages/babel-plugin-minify-mangle-names/src/get-binding-identifiers.js
@@ -1,0 +1,71 @@
+/**
+ * Original Source: https://github.com/babel/babel/blob/master/packages/babel-types/src/retrievers.js
+ *
+ * The original source is able to return only a Node. But we need Path to work around
+ * this bug when used with BlockScoping Plugin or ES2015 preset
+ * - The same Node {type: Identifier, name: "x"} object results in being used
+ *   in multiple places - binding, binding reference,
+ *   and another binding with same name in a different scope
+ *
+ * - This might be moved to babel in future
+ *
+ * Note:
+ * This uses the KEYS from the original implementation from Babel
+ *
+ */
+module.exports = function (t) {
+  const KEYS = t.getBindingIdentifiers.keys;
+
+  return function getBindingIdentifiers(path, duplicates = false, outerOnly = false) {
+    let search = [].concat(path);
+    let ids = Object.create(null);
+
+    while (search.length) {
+      let id = search.shift();
+      if (!id) continue;
+      if (!id.node) continue;
+
+      let keys = KEYS[id.node.type];
+
+      if (id.isIdentifier()) {
+        if (duplicates) {
+          let _ids = ids[id.node.name] = ids[id.node.name] || [];
+          _ids.push(id);
+        } else {
+          ids[id.node.name] = id;
+        }
+        continue;
+      }
+
+      if (id.isExportDeclaration()) {
+        const declaration = id.get("declaration");
+        if (declaration.isDeclaration()) {
+          search.push(declaration);
+        }
+        continue;
+      }
+
+      if (outerOnly) {
+        if (id.isFunctionDeclaration()) {
+          search.push(id.get("id"));
+          continue;
+        }
+        if (id.isFunctionExpression()) {
+          continue;
+        }
+      }
+
+      if (keys) {
+        for (let i = 0; i < keys.length; i++) {
+          let key = keys[i];
+          const child = id.get(key);
+          if (child.node) {
+            search = search.concat(child);
+          }
+        }
+      }
+    }
+
+    return ids;
+  };
+};

--- a/packages/babel-plugin-minify-mangle-names/src/index.js
+++ b/packages/babel-plugin-minify-mangle-names/src/index.js
@@ -11,7 +11,7 @@ module.exports = ({ types: t, traverse }) => {
       keepFnName = false,
       keepClassName = false,
       eval: _eval = false,
-      reuse = false,
+      reuse = true,
     } = {}) {
       this.charset = charset;
       this.program = program;

--- a/packages/babel-plugin-minify-mangle-names/src/index.js
+++ b/packages/babel-plugin-minify-mangle-names/src/index.js
@@ -1,12 +1,17 @@
-module.exports = ({ types: t }) => {
+const _getBindingIdentifiers = require("./get-binding-identifiers");
+const CountedSet = require("./counted-set");
+
+module.exports = ({ types: t, traverse }) => {
   const hop = Object.prototype.hasOwnProperty;
+  const getBindingIdentifiers = _getBindingIdentifiers(t);
 
   class Mangler {
     constructor(charset, program, {
       blacklist = {},
       keepFnName = false,
       keepClassName = false,
-      eval: _eval = false
+      eval: _eval = false,
+      reuse = false,
     } = {}) {
       this.charset = charset;
       this.program = program;
@@ -14,14 +19,152 @@ module.exports = ({ types: t }) => {
       this.keepFnName = keepFnName;
       this.keepClassName = keepClassName;
       this.eval = _eval;
+      this.reuse = reuse;
 
       this.unsafeScopes = new Set;
       this.visitedScopes = new Set;
 
-      this.referencesToUpdate = new Map;
+      this.references = new Map;
+      this.bindings = new Map;
+
+      this.renamedNodes = new Set;
+    }
+
+    addScope(scope) {
+      if (!this.references.has(scope)) {
+        this.references.set(scope, new CountedSet);
+      }
+      if (!this.bindings.has(scope)) {
+        this.bindings.set(scope, new Map);
+      }
+    }
+
+    updateScope(scope) {
+      const mangler = this;
+      scope.path.traverse({
+        ReferencedIdentifier(path) {
+          if (path.scope === scope) {
+            const binding = scope.getBinding(path.node.name);
+            mangler.addReference(scope, binding, path.node.name);
+          }
+        }
+      });
+    }
+
+    addReference(scope, binding, name) {
+      let parent = scope;
+      do {
+        if (!this.references.has(parent)) {
+          this.addScope(parent);
+          this.updateScope(parent);
+        }
+        this.references.get(parent).add(name);
+
+        // here binding is undefined for globals,
+        // so we just add to all scopes up
+        if (binding && binding.scope === parent) {
+          break;
+        }
+      } while (parent = parent.parent);
+    }
+
+    hasReference(scope, name) {
+      if (!this.reuse) {
+        return scope.hasReference(name);
+      }
+      if (!this.references.has(scope)) {
+        this.addScope(scope);
+        this.updateScope(scope);
+      }
+      return this.references.get(scope).has(name);
+    }
+
+    canUseInReferencedScopes(binding, next) {
+      const mangler = this;
+
+      if (mangler.hasReference(binding.scope, next)) {
+        return false;
+      }
+
+      for (let i = 0; i < binding.constantViolations.length; i++) {
+        const violation = binding.constantViolations[i];
+        if (mangler.hasReference(violation.scope, next)) {
+          return false;
+        }
+      }
+
+      for (let i = 0; i < binding.referencePaths; i++) {
+        const ref = binding.referencePaths[i];
+        if (!ref.isIdentifier()) {
+          let canUse = true;
+          ref.traverse({
+            ReferencedIdentifier(path) {
+              if (path.node.name !== next) return;
+              if (mangler.hasReference(path.scope, next)) {
+                canUse = false;
+              }
+            }
+          });
+          if (!canUse) {
+            return canUse;
+          }
+        } else if (!isLabelIdentifier(ref)) {
+          if (mangler.hasReference(ref.scope, next)) {
+            return false;
+          }
+        }
+      }
+
+      return true;
+    }
+
+    updateReference(scope, binding, oldName, newName) {
+      let parent = scope;
+      do {
+        if (!this.references.has(parent)) {
+          this.addScope(parent);
+          this.updateScope(parent);
+        }
+
+        // update
+        const ref = this.references.get(parent);
+        if (ref.has(oldName)) {
+          ref.delete(oldName);
+          ref.add(newName);
+        }
+        // else already renamed
+
+        if (binding.scope === parent) {
+          break;
+        }
+      } while (parent = parent.parent);
+    }
+
+    addBinding(binding) {
+      if (!binding) {
+        return;
+      }
+      const bindings = this.bindings.get(binding.scope);
+      if (!bindings.has(binding.identifier.name)) {
+        bindings.set(binding.identifier.name, binding);
+      }
+    }
+
+    hasBinding(scope, name) {
+      if (!this.reuse) {
+        return scope.hasBinding(name);
+      }
+      return this.bindings.get(scope).has(name);
+    }
+
+    renameBinding(scope, oldName, newName) {
+      const bindings = this.bindings.get(scope);
+      bindings.set(newName, bindings.get(oldName));
+      bindings.delete(oldName);
     }
 
     run() {
+      this.crawlScope();
       this.collect();
       this.charset.sort();
       this.mangle();
@@ -38,8 +181,15 @@ module.exports = ({ types: t }) => {
       } while (evalScope = evalScope.parent);
     }
 
+    crawlScope() {
+      traverse.clearCache();
+      this.program.scope.crawl();
+    }
+
     collect() {
       const mangler = this;
+
+      mangler.addScope(this.program.scope);
 
       const collectVisitor = {
         // capture direct evals
@@ -51,6 +201,66 @@ module.exports = ({ types: t }) => {
             && !callee.scope.getBinding("eval")
           ) {
             mangler.markUnsafeScopes(path.scope);
+          }
+        },
+        Scopable({scope}) {
+          mangler.addScope(scope);
+          Object.keys(scope.bindings).forEach((name) => {
+            mangler.addBinding(scope.bindings[name]);
+          });
+        },
+        ReferencedIdentifier(path) {
+          if (isLabelIdentifier(path)) return;
+          const {scope, node: {name}} = path;
+          const binding = scope.getBinding(name);
+          mangler.addReference(scope, binding, name);
+        },
+        // this fixes a bug where converting let to var
+        // doesn't change the binding's scope to function scope
+        VariableDeclaration: {
+          enter(path) {
+            if (path.node.kind !== "var") {
+              return;
+            }
+            const ids = path.getOuterBindingIdentifiers();
+            const fnScope = path.scope.getFunctionParent();
+            Object.keys(ids).forEach((id) => {
+              let binding = path.scope.getBinding(id);
+
+              if (binding.scope !== fnScope) {
+                const existingBinding = fnScope.bindings[id];
+                if (!existingBinding) {
+                  // move binding to the function scope
+                  fnScope.bindings[id] = binding;
+                  binding.scope = fnScope;
+                  delete binding.scope.bindings[id];
+                } else {
+                  // we need a new binding that's valid in both the scopes
+                  // binding.scope and fnScope
+                  const newName = fnScope.generateUid(binding.scope.generateUid(id));
+
+                  // rename binding in the original scope
+                  mangler.rename(binding.scope, binding, id, newName);
+
+                  // move binding to fnScope as newName
+                  fnScope.bindings[newName] = binding;
+                  binding.scope = fnScope;
+                  delete binding.scope.bindings[newName];
+                }
+              }
+            });
+          }
+        },
+        BindingIdentifier: {
+          exit(path) {
+            if (isLabelIdentifier(path)) return;
+            const {scope, node: {name}} = path;
+            let binding = scope.getBinding(name);
+            if (!binding) {
+              if (scope.hasGlobal(name)) return;
+              throw new Error("binding not found " + name);
+            }
+            mangler.addBinding(binding);
           }
         }
       };
@@ -99,20 +309,16 @@ module.exports = ({ types: t }) => {
           // => var aa, a, b ,c;
           // instead of
           // => var aa, ab, ...;
-          // TODO:
-          // Re-enable after enabling this feature
-          // This doesn't work right now as we are concentrating
-          // on performance improvements
-          // function resetNext() {
-          //   i = 0;
-          // }
+          function resetNext() {
+            i = 0;
+          }
 
-          const bindings = scope.getAllBindings();
-          const names = Object.keys(bindings);
+          const bindings = mangler.bindings.get(scope);
+          const names = [...bindings.keys()];
 
           for (let i = 0; i < names.length; i++) {
             const oldName = names[i];
-            const binding = bindings[oldName];
+            const binding = bindings.get(oldName);
 
             if (
               // already renamed bindings
@@ -121,8 +327,6 @@ module.exports = ({ types: t }) => {
               || oldName === "arguments"
               // globals
               || mangler.program.scope.bindings[oldName] === binding
-              // other scope bindings
-              || !scope.hasOwnBinding(oldName)
               // labels
               || binding.path.isLabeledStatement()
               // blacklisted
@@ -140,48 +344,59 @@ module.exports = ({ types: t }) => {
               next = getNext();
             } while (
               !t.isValidIdentifier(next)
-              || hop.call(bindings, next)
+              || mangler.hasBinding(scope, next)
               || scope.hasGlobal(next)
-              || scope.hasReference(next)
+              || mangler.hasReference(scope, next)
+              || !mangler.canUseInReferencedScopes(binding, next)
             );
 
-            // TODO:
-            // re-enable this - check above
-            // resetNext();
-            mangler.rename(scope, oldName, next);
+            resetNext();
+            mangler.rename(scope, binding, oldName, next);
             // mark the binding as renamed
             binding.renamed = true;
           }
         }
       });
-
-      // TODO:
-      // re-enable
-      // check above
-      // this.updateReferences();
     }
 
-    rename(scope, oldName, newName) {
-      const binding = scope.getBinding(oldName);
+    renameBindingIds(path, oldName, newName) {
+      const bindingIds = getBindingIdentifiers(path, true, false);
+      const names = Object.keys(bindingIds);
+      let replace = [];
+
+      for (let i = 0; i < names.length; i++) {
+        if (names[i] !== oldName) continue;
+        const idPath = bindingIds[names[i]];
+        if (Array.isArray(idPath)) {
+          replace = replace.concat(idPath);
+        } else {
+          replace.push(idPath);
+        }
+      }
+
+      for (let i = 0; i < replace.length; i++) {
+        const idPath = replace[i];
+        this.renamedNodes.add(idPath.node);
+        idPath.replaceWith(t.identifier(newName));
+        this.renamedNodes.add(idPath.node);
+      }
+    }
+
+    rename(scope, binding, oldName, newName) {
+      const mangler = this;
 
       // rename at the declaration level
-      binding.identifier.name = newName;
-
-      const {bindings} = scope;
-      bindings[newName] = binding;
-      delete bindings[oldName];
+      // binding.identifier.name = newName;
+      this.renameBindingIds(binding.path, oldName, newName);
+      // update bindings map
+      this.renameBinding(scope, oldName, newName);
 
       // update all constant violations & redeclarations
       const violations = binding.constantViolations;
       for (let i = 0; i < violations.length; i++) {
-        if (violations[i].isLabeledStatement()) continue;
-
-        const bindings = violations[i].getBindingIdentifiers();
-        Object
-          .keys(bindings)
-          .map((b) => {
-            bindings[b].name = newName;
-          });
+        if (!violations[i].isLabeledStatement()) {
+          this.renameBindingIds(violations[i], oldName, newName);
+        }
       }
 
       // update all referenced places
@@ -189,6 +404,7 @@ module.exports = ({ types: t }) => {
       for (let i = 0; i < refs.length; i++) {
         const path = refs[i];
         const {node} = path;
+
         if (!path.isIdentifier()) {
           // Ideally, this should not happen
           // it happens in these places now -
@@ -200,32 +416,64 @@ module.exports = ({ types: t }) => {
           // replacement in dce from `x` to `!x` gives referencePath as `!x`
           path.traverse({
             ReferencedIdentifier(refPath) {
-              if (refPath.node.name === oldName && refPath.scope === scope) {
-                refPath.node.name = newName;
+              if (refPath.node.name !== oldName) {
+                return;
               }
+              const actualBinding = refPath.scope.getBinding(oldName);
+              if (actualBinding !== binding) {
+                return;
+              }
+              mangler.renamedNodes.add(refPath.node);
+              refPath.replaceWith(t.identifier(newName));
+              mangler.renamedNodes.add(refPath.node);
+
+              mangler.updateReference(refPath.scope, binding, oldName, newName);
             }
           });
         } else if (!isLabelIdentifier(path)) {
-          node.name = newName;
+          if (path.node.name === oldName) {
+            mangler.renamedNodes.add(path.node);
+            path.replaceWith(t.identifier(newName));
+            mangler.renamedNodes.add(path.node);
+
+            mangler.updateReference(path.scope, binding, oldName, newName);
+          } else if (mangler.renamedNodes.has(path.node)) {
+            // already renamed,
+            // just update the references
+            mangler.updateReference(path.scope, binding, oldName, newName);
+          } else {
+            throw new Error(
+              `Unexpected Error - Trying to replace ${node.name}: from ${oldName} to ${newName}`
+            );
+          }
         }
+        // else label
       }
+
+      // update scope tracking
+      const {bindings} = scope;
+      bindings[newName] = binding;
+      delete bindings[oldName];
     }
   }
 
+  let mangler;
   return {
     name: "minify-mangle-names",
     visitor: {
-      Program(path) {
-        // If the source code is small then we're going to assume that the user
-        // is running on this on single files before bundling. Therefore we
-        // need to achieve as much determinisim and we will not do any frequency
-        // sorting on the character set. Currently the number is pretty arbitrary.
-        const shouldConsiderSource = path.getSource().length > 70000;
+      Program: {
+        exit(path) {
+          // If the source code is small then we're going to assume that the user
+          // is running on this on single files before bundling. Therefore we
+          // need to achieve as much determinisim and we will not do any frequency
+          // sorting on the character set. Currently the number is pretty arbitrary.
+          const shouldConsiderSource = path.getSource().length > 70000;
 
-        const charset = new Charset(shouldConsiderSource);
+          const charset = new Charset(shouldConsiderSource);
 
-        const mangler = new Mangler(charset, path, this.opts);
-        mangler.run();
+          mangler = new Mangler(charset, path, this.opts);
+          mangler.run();
+        }
       },
     },
   };

--- a/packages/babel-plugin-minify-mangle-names/src/index.js
+++ b/packages/babel-plugin-minify-mangle-names/src/index.js
@@ -350,7 +350,9 @@ module.exports = ({ types: t, traverse }) => {
               || !mangler.canUseInReferencedScopes(binding, next)
             );
 
-            resetNext();
+            if (mangler.reuse) {
+              resetNext();
+            }
             mangler.rename(scope, binding, oldName, next);
             // mark the binding as renamed
             binding.renamed = true;

--- a/packages/babel-preset-babili/__tests__/preset-tests.js
+++ b/packages/babel-preset-babili/__tests__/preset-tests.js
@@ -33,8 +33,8 @@ describe("preset", () => {
     `);
     const expected = unpad(`
       function foo() {
-        var d, e, f;
-        d ? e && f : e || f;
+        var d, a, b;
+        d ? a && b : a || b;
       }
     `);
     expect(transform(source)).toBe(expected);

--- a/packages/babel-preset-babili/__tests__/preset-tests.js
+++ b/packages/babel-preset-babili/__tests__/preset-tests.js
@@ -8,7 +8,7 @@ function transform(code, options = {}, sourceType = "script") {
     sourceType,
     minified: false,
     presets: [
-      require("../src/index")
+      [require("../src/index"), options]
     ],
   }).code;
 }
@@ -60,5 +60,45 @@ describe("preset", () => {
       var asdf = 1;
     `);
     expect(transform(source)).toBe(expected);
+  });
+
+  it("should fix bug#326 - object destructuring", () => {
+    const source = unpad(`
+      function a() {
+        let foo, bar, baz;
+        ({foo, bar, baz} = {});
+        return {foo, bar, baz};
+      }
+    `);
+    const expected = unpad(`
+      function a() {
+        let a, b, c;
+
+        return ({ foo: a, bar: b, baz: c } = {}), { foo: a, bar: b, baz: c };
+      }
+    `);
+    expect(transform(source)).toBe(expected);
+  });
+
+  it("should fix bug#326 - object destructuring", () => {
+    const source = unpad(`
+      function a() {
+        let foo, bar, baz;
+        ({foo, bar, baz} = {});
+        return {foo, bar, baz};
+      }
+    `);
+    const expected = unpad(`
+      function a() {
+        let b, c, d;
+
+        return ({ foo: b, bar: c, baz: d } = {}), { foo: b, bar: c, baz: d };
+      }
+    `);
+    expect(transform(source, {
+      mangle: {
+        reuse: false
+      }
+    })).toBe(expected);
   });
 });


### PR DESCRIPTION
Adds a new mangler option - `reuse` when set to true reuses vars which are removed and not yet used in the current scope. 

Test suite:

Now this contains two test suites with identical tests - one uses default option, and the other uses `reuse=true`.

perf fixes:

+ [x] use `reuse` option in calculating resetnext
+ [ ] TopLevel option
+ [ ] don't traverse scope.crawl when not reusing
+ [ ] don't collect Refs and Bindings when reuse is false