### PR TITLE
Escape unicode newline in regex optimization

### DIFF
--- a/packages/babel-plugin-transform-regexp-constructors/__tests__/transform-regexp-constructors-test.js
+++ b/packages/babel-plugin-transform-regexp-constructors/__tests__/transform-regexp-constructors-test.js
@@ -22,6 +22,12 @@ describe("transform-regexp-constructors-plugin", () => {
     expect(transform(source)).toBe(expected);
   });
 
+  it("should transform unicode newlines fine", () => {
+    const source = String.raw`var x = new RegExp('\u2028\u2029');`;
+    const expected = String.raw`var x = /\u2028\u2029/;`;
+    expect(transform(source)).toBe(expected);
+  });
+
   it("should transform RegExp constructors with string literals", () => {
     const source = "var x = new RegExp('ab+c');";
     const expected = "var x = /ab+c/;";

--- a/packages/babel-plugin-transform-regexp-constructors/src/index.js
+++ b/packages/babel-plugin-transform-regexp-constructors/src/index.js
@@ -17,6 +17,8 @@ function createRegExpLiteral(args, prettify, t) {
   pattern = new RegExp(pattern).source;
   if (prettify) {
     pattern = pattern.replace(/\n/g, "\\n")
+                     .replace(/\u2028/g, "\\u2028")
+                     .replace(/\u2029/g, "\\u2029")
                      .replace(/[\b]/g, "[\\b]")
                      .replace(/\v/g, "\\v")
                      .replace(/\f/g, "\\f")


### PR DESCRIPTION
[In javascript \u2028 and \u2029 count as newlines too](http://www.ecma-international.org/ecma-262/5.1/#sec-7.3) (in addition to \u000a or \n and \u000d or \r).

Since only \r and \n are properly escaped this PR adds \u2028 and \u2029.