### PR TITLE
Pass per preset the babili plugins

### DIFF
--- a/packages/babel-preset-babili/__tests__/options-tests.js
+++ b/packages/babel-preset-babili/__tests__/options-tests.js
@@ -31,7 +31,7 @@ mocks.forEach((mockName) => {
 const preset = require("../src/index");
 
 function getPlugins(opts) {
-  return preset({}, opts).plugins;
+  return preset({}, opts).presets[0].plugins;
 }
 
 function testOpts(opts) {

--- a/packages/babel-preset-babili/src/index.js
+++ b/packages/babel-preset-babili/src/index.js
@@ -100,6 +100,9 @@ function preset(context, _opts = {}) {
 
   return {
     minified: true,
-    plugins,
+    presets: [
+      { plugins }
+    ],
+    passPerPreset: true,
   };
 }


### PR DESCRIPTION
This should fix most of the bugs that are caused by using it with es2015 preset or other plugins.