### PR TITLE
Remove dollar from sh snippets

### DIFF
--- a/packages/babel-helper-evaluate-path/README.md
+++ b/packages/babel-helper-evaluate-path/README.md
@@ -5,5 +5,5 @@
 ## Installation
 
 ```sh
-$ npm install babel-helper-evaluate-path
+npm install babel-helper-evaluate-path
 ```

--- a/packages/babel-helper-flip-expressions/README.md
+++ b/packages/babel-helper-flip-expressions/README.md
@@ -3,5 +3,5 @@
 ## Installation
 
 ```sh
-$ npm install babel-helper-flip-expressions
+npm install babel-helper-flip-expressions
 ```

--- a/packages/babel-helper-is-void-0/README.md
+++ b/packages/babel-helper-is-void-0/README.md
@@ -3,5 +3,5 @@
 ## Installation
 
 ```sh
-$ npm install babel-helper-is-void-0
+npm install babel-helper-is-void-0
 ```

--- a/packages/babel-helper-remove-or-void/README.md
+++ b/packages/babel-helper-remove-or-void/README.md
@@ -3,5 +3,5 @@
 ## Installation
 
 ```sh
-$ npm install babel-helper-remove-or-void
+npm install babel-helper-remove-or-void
 ```

--- a/packages/babel-helper-to-multiple-sequence-expressions/README.md
+++ b/packages/babel-helper-to-multiple-sequence-expressions/README.md
@@ -3,5 +3,5 @@
 ## Installation
 
 ```sh
-$ npm install babel-helper-to-multiple-sequence-expressions
+npm install babel-helper-to-multiple-sequence-expressions
 ```

--- a/packages/babel-plugin-minify-constant-folding/README.md
+++ b/packages/babel-plugin-minify-constant-folding/README.md
@@ -25,7 +25,7 @@ Tries to evaluate expressions and inline the result. For now only deals with num
 ## Installation
 
 ```sh
-$ npm install babel-plugin-minify-constant-folding
+npm install babel-plugin-minify-constant-folding
 ```
 
 ## Usage
@@ -43,7 +43,7 @@ $ npm install babel-plugin-minify-constant-folding
 ### Via CLI
 
 ```sh
-$ babel --plugins minify-constant-folding script.js
+babel --plugins minify-constant-folding script.js
 ```
 
 ### Via Node API

--- a/packages/babel-plugin-minify-dead-code-elimination/README.md
+++ b/packages/babel-plugin-minify-dead-code-elimination/README.md
@@ -30,7 +30,7 @@ foo(0);
 ## Installation
 
 ```sh
-$ npm install babel-plugin-minify-dead-code-elimination
+npm install babel-plugin-minify-dead-code-elimination
 ```
 
 ## Usage
@@ -54,7 +54,7 @@ $ npm install babel-plugin-minify-dead-code-elimination
 ### Via CLI
 
 ```sh
-$ babel --plugins minify-dead-code-elimination script.js
+babel --plugins minify-dead-code-elimination script.js
 ```
 
 ### Via Node API

--- a/packages/babel-plugin-minify-empty-function/README.md
+++ b/packages/babel-plugin-minify-empty-function/README.md
@@ -22,7 +22,7 @@ foo(false);
 ## Installation
 
 ```sh
-$ npm install babel-plugin-minify-empty-function
+npm install babel-plugin-minify-empty-function
 ```
 
 ## Usage
@@ -40,7 +40,7 @@ $ npm install babel-plugin-minify-empty-function
 ### Via CLI
 
 ```sh
-$ babel --plugins minify-empty-function script.js
+babel --plugins minify-empty-function script.js
 ```
 
 ### Via Node API

--- a/packages/babel-plugin-minify-flip-comparisons/README.md
+++ b/packages/babel-plugin-minify-flip-comparisons/README.md
@@ -25,7 +25,7 @@ if (null !== bar) {
 ## Installation
 
 ```sh
-$ npm install babel-plugin-minify-flip-comparisons
+npm install babel-plugin-minify-flip-comparisons
 ```
 
 ## Usage
@@ -43,7 +43,7 @@ $ npm install babel-plugin-minify-flip-comparisons
 ### Via CLI
 
 ```sh
-$ babel --plugins minify-flip-comparisons script.js
+babel --plugins minify-flip-comparisons script.js
 ```
 
 ### Via Node API

--- a/packages/babel-plugin-minify-guarded-expressions/README.md
+++ b/packages/babel-plugin-minify-guarded-expressions/README.md
@@ -19,7 +19,7 @@ alert(0);
 ## Installation
 
 ```sh
-$ npm install babel-plugin-minify-guarded-expressions
+npm install babel-plugin-minify-guarded-expressions
 ```
 
 ## Usage
@@ -37,7 +37,7 @@ $ npm install babel-plugin-minify-guarded-expressions
 ### Via CLI
 
 ```sh
-$ babel --plugins minify-guarded-expressions script.js
+babel --plugins minify-guarded-expressions script.js
 ```
 
 ### Via Node API

--- a/packages/babel-plugin-minify-infinity/README.md
+++ b/packages/babel-plugin-minify-infinity/README.md
@@ -17,7 +17,7 @@ Infinity;
 ## Installation
 
 ```sh
-$ npm install babel-plugin-minify-infinity
+npm install babel-plugin-minify-infinity
 ```
 
 ## Usage
@@ -35,7 +35,7 @@ $ npm install babel-plugin-minify-infinity
 ### Via CLI
 
 ```sh
-$ babel --plugins minify-infinity script.js
+babel --plugins minify-infinity script.js
 ```
 
 ### Via Node API

--- a/packages/babel-plugin-minify-mangle-names/README.md
+++ b/packages/babel-plugin-minify-mangle-names/README.md
@@ -31,7 +31,7 @@ function foo() {
 ## Installation
 
 ```sh
-$ npm install babel-plugin-minify-mangle-names
+npm install babel-plugin-minify-mangle-names
 ```
 
 ## Usage
@@ -55,7 +55,7 @@ $ npm install babel-plugin-minify-mangle-names
 ### Via CLI
 
 ```sh
-$ babel --plugins minify-mangle-names script.js
+babel --plugins minify-mangle-names script.js
 ```
 
 ### Via Node API

--- a/packages/babel-plugin-minify-numeric-literals/README.md
+++ b/packages/babel-plugin-minify-numeric-literals/README.md
@@ -19,7 +19,7 @@ Shortening of numeric literals via scientific notation
 ## Installation
 
 ```sh
-$ npm install babel-plugin-minify-numeric-literals
+npm install babel-plugin-minify-numeric-literals
 ```
 
 ## Usage
@@ -37,7 +37,7 @@ $ npm install babel-plugin-minify-numeric-literals
 ### Via CLI
 
 ```sh
-$ babel --plugins minify-numeric-literals script.js
+babel --plugins minify-numeric-literals script.js
 ```
 
 ### Via Node API

--- a/packages/babel-plugin-minify-replace/README.md
+++ b/packages/babel-plugin-minify-replace/README.md
@@ -43,7 +43,7 @@ if (a.__DEV__) {
 ## Installation
 
 ```sh
-$ npm install babel-plugin-minify-replace
+npm install babel-plugin-minify-replace
 ```
 
 ## Usage
@@ -77,7 +77,7 @@ $ npm install babel-plugin-minify-replace
 ### Via CLI
 
 ```sh
-$ babel --plugins minify-replace script.js
+babel --plugins minify-replace script.js
 ```
 
 ### Via Node API

--- a/packages/babel-plugin-minify-simplify/README.md
+++ b/packages/babel-plugin-minify-simplify/README.md
@@ -45,7 +45,7 @@ foo.bar
 ## Installation
 
 ```sh
-$ npm install babel-plugin-minify-simplify
+npm install babel-plugin-minify-simplify
 ```
 
 ## Usage
@@ -63,7 +63,7 @@ $ npm install babel-plugin-minify-simplify
 ### Via CLI
 
 ```sh
-$ babel --plugins minify-simplify script.js
+babel --plugins minify-simplify script.js
 ```
 
 ### Via Node API

--- a/packages/babel-plugin-minify-type-constructors/README.md
+++ b/packages/babel-plugin-minify-type-constructors/README.md
@@ -29,7 +29,7 @@ x + "";
 ## Installation
 
 ```sh
-$ npm install babel-plugin-minify-type-constructors
+npm install babel-plugin-minify-type-constructors
 ```
 
 ## Usage
@@ -47,7 +47,7 @@ $ npm install babel-plugin-minify-type-constructors
 ### Via CLI
 
 ```sh
-$ babel --plugins minify-type-constructors script.js
+babel --plugins minify-type-constructors script.js
 ```
 
 ### Via Node API

--- a/packages/babel-plugin-transform-inline-consecutive-adds/README.md
+++ b/packages/babel-plugin-transform-inline-consecutive-adds/README.md
@@ -36,7 +36,7 @@ const bar = [1, 2];
 ## Installation
 
 ```sh
-$ npm install babel-plugin-transform-inline-consecutive-adds
+npm install babel-plugin-transform-inline-consecutive-adds
 ```
 
 ## Usage
@@ -54,7 +54,7 @@ $ npm install babel-plugin-transform-inline-consecutive-adds
 ### Via CLI
 
 ```sh
-$ babel --plugins transform-inline-consecutive-adds script.js
+babel --plugins transform-inline-consecutive-adds script.js
 ```
 
 ### Via Node API

--- a/packages/babel-plugin-transform-inline-environment-variables/README.md
+++ b/packages/babel-plugin-transform-inline-environment-variables/README.md
@@ -20,7 +20,7 @@ process.env.NODE_ENV;
 ## Installation
 
 ```sh
-$ npm install babel-plugin-transform-inline-environment-variables
+npm install babel-plugin-transform-inline-environment-variables
 ```
 
 ## Usage
@@ -38,7 +38,7 @@ $ npm install babel-plugin-transform-inline-environment-variables
 ### Via CLI
 
 ```sh
-$ babel --plugins transform-inline-environment-variables script.js
+babel --plugins transform-inline-environment-variables script.js
 ```
 
 ### Via Node API

--- a/packages/babel-plugin-transform-member-expression-literals/README.md
+++ b/packages/babel-plugin-transform-member-expression-literals/README.md
@@ -25,7 +25,7 @@ obj["var"] = "isKeyword";
 ## Installation
 
 ```sh
-$ npm install babel-plugin-transform-member-expression-literals
+npm install babel-plugin-transform-member-expression-literals
 ```
 
 ## Usage
@@ -43,7 +43,7 @@ $ npm install babel-plugin-transform-member-expression-literals
 ### Via CLI
 
 ```sh
-$ babel --plugins transform-member-expression-literals script.js
+babel --plugins transform-member-expression-literals script.js
 ```
 
 ### Via Node API

--- a/packages/babel-plugin-transform-merge-sibling-variables/README.md
+++ b/packages/babel-plugin-transform-merge-sibling-variables/README.md
@@ -30,7 +30,7 @@ for (var i = 0, x = 0; x < 10; x++) {}
 ## Installation
 
 ```sh
-$ npm install babel-plugin-transform-merge-sibling-variables
+npm install babel-plugin-transform-merge-sibling-variables
 ```
 
 ## Usage
@@ -48,7 +48,7 @@ $ npm install babel-plugin-transform-merge-sibling-variables
 ### Via CLI
 
 ```sh
-$ babel --plugins transform-merge-sibling-variables script.js
+babel --plugins transform-merge-sibling-variables script.js
 ```
 
 ### Via Node API

--- a/packages/babel-plugin-transform-minify-booleans/README.md
+++ b/packages/babel-plugin-transform-minify-booleans/README.md
@@ -21,7 +21,7 @@ false;
 ## Installation
 
 ```sh
-$ npm install babel-plugin-transform-minify-booleans
+npm install babel-plugin-transform-minify-booleans
 ```
 
 ## Usage
@@ -39,7 +39,7 @@ $ npm install babel-plugin-transform-minify-booleans
 ### Via CLI
 
 ```sh
-$ babel --plugins transform-minify-booleans script.js
+babel --plugins transform-minify-booleans script.js
 ```
 
 ### Via Node API

--- a/packages/babel-plugin-transform-node-env-inline/README.md
+++ b/packages/babel-plugin-transform-node-env-inline/README.md
@@ -15,7 +15,7 @@ process.env.NODE_ENV === "production";
 **Out**
 
 ```sh
-$ NODE_ENV=development babel in.js --plugins transform-node-env-inline
+NODE_ENV=development babel in.js --plugins transform-node-env-inline
 ```
 
 ```javascript
@@ -26,7 +26,7 @@ false;
 ## Installation
 
 ```sh
-$ npm install babel-plugin-transform-node-env-inline
+npm install babel-plugin-transform-node-env-inline
 ```
 
 ## Usage
@@ -44,7 +44,7 @@ $ npm install babel-plugin-transform-node-env-inline
 ### Via CLI
 
 ```sh
-$ babel --plugins transform-node-env-inline script.js
+babel --plugins transform-node-env-inline script.js
 ```
 
 ### Via Node API

--- a/packages/babel-plugin-transform-property-literals/README.md
+++ b/packages/babel-plugin-transform-property-literals/README.md
@@ -35,7 +35,7 @@ var foo = {
 ## Installation
 
 ```sh
-$ npm install babel-plugin-transform-property-literals
+npm install babel-plugin-transform-property-literals
 ```
 
 ## Usage
@@ -53,7 +53,7 @@ $ npm install babel-plugin-transform-property-literals
 ### Via CLI
 
 ```sh
-$ babel --plugins transform-property-literals script.js
+babel --plugins transform-property-literals script.js
 ```
 
 ### Via Node API

--- a/packages/babel-plugin-transform-regexp-constructors/README.md
+++ b/packages/babel-plugin-transform-regexp-constructors/README.md
@@ -21,7 +21,7 @@ var a = /ab+c/i;
 ## Installation
 
 ```sh
-$ npm install babel-plugin-transform-regexp-constructors
+npm install babel-plugin-transform-regexp-constructors
 ```
 
 ## Usage
@@ -39,7 +39,7 @@ $ npm install babel-plugin-transform-regexp-constructors
 ### Via CLI
 
 ```sh
-$ babel --plugins transform-regexp-constructors script.js
+babel --plugins transform-regexp-constructors script.js
 ```
 
 ### Via Node API

--- a/packages/babel-plugin-transform-remove-console/README.md
+++ b/packages/babel-plugin-transform-remove-console/README.md
@@ -19,7 +19,7 @@ console.error("bar");
 ## Installation
 
 ```sh
-$ npm install babel-plugin-transform-remove-console
+npm install babel-plugin-transform-remove-console
 ```
 
 ## Usage
@@ -37,7 +37,7 @@ $ npm install babel-plugin-transform-remove-console
 ### Via CLI
 
 ```sh
-$ babel --plugins transform-remove-console script.js
+babel --plugins transform-remove-console script.js
 ```
 
 ### Via Node API

--- a/packages/babel-plugin-transform-remove-debugger/README.md
+++ b/packages/babel-plugin-transform-remove-debugger/README.md
@@ -18,7 +18,7 @@ debugger;
 ## Installation
 
 ```sh
-$ npm install babel-plugin-transform-remove-debugger
+npm install babel-plugin-transform-remove-debugger
 ```
 
 ## Usage
@@ -36,7 +36,7 @@ $ npm install babel-plugin-transform-remove-debugger
 ### Via CLI
 
 ```sh
-$ babel --plugins transform-remove-debugger script.js
+babel --plugins transform-remove-debugger script.js
 ```
 
 ### Via Node API

--- a/packages/babel-plugin-transform-remove-undefined/README.md
+++ b/packages/babel-plugin-transform-remove-undefined/README.md
@@ -29,7 +29,7 @@ function foo() {
 ## Installation
 
 ```sh
-$ npm install babel-plugin-transform-remove-undefined
+npm install babel-plugin-transform-remove-undefined
 ```
 
 ## Usage
@@ -47,7 +47,7 @@ $ npm install babel-plugin-transform-remove-undefined
 ### Via CLI
 
 ```sh
-$ babel --plugins babel-plugin-transform-remove-undefined script.js
+babel --plugins babel-plugin-transform-remove-undefined script.js
 ```
 
 ### Via Node API

--- a/packages/babel-plugin-transform-simplify-comparison-operators/README.md
+++ b/packages/babel-plugin-transform-simplify-comparison-operators/README.md
@@ -19,7 +19,7 @@ typeof foo == "object";
 ## Installation
 
 ```sh
-$ npm install babel-plugin-transform-simplify-comparison-operators
+npm install babel-plugin-transform-simplify-comparison-operators
 ```
 
 ## Usage
@@ -37,7 +37,7 @@ $ npm install babel-plugin-transform-simplify-comparison-operators
 ### Via CLI
 
 ```sh
-$ babel --plugins transform-simplify-comparison-operators script.js
+babel --plugins transform-simplify-comparison-operators script.js
 ```
 
 ### Via Node API

--- a/packages/babel-plugin-transform-undefined-to-void/README.md
+++ b/packages/babel-plugin-transform-undefined-to-void/README.md
@@ -21,7 +21,7 @@ foo === void 0;
 ## Installation
 
 ```sh
-$ npm install babel-plugin-transform-undefined-to-void
+npm install babel-plugin-transform-undefined-to-void
 ```
 
 ## Usage
@@ -39,7 +39,7 @@ $ npm install babel-plugin-transform-undefined-to-void
 ### Via CLI
 
 ```sh
-$ babel --plugins transform-undefined-to-void script.js
+babel --plugins transform-undefined-to-void script.js
 ```
 
 ### Via Node API

--- a/packages/babel-preset-babili/README.md
+++ b/packages/babel-preset-babili/README.md
@@ -9,7 +9,7 @@ Babel preset for all minify plugins.
 ## Install
 
 ```sh
-$ npm install --save-dev babel-preset-babili
+npm install --save-dev babel-preset-babili
 ```
 
 ## Usage
@@ -43,7 +43,7 @@ or pass in options -
 ### Via CLI
 
 ```sh
-$ babel script.js --presets babili
+babel script.js --presets babili
 ```
 
 ### Via Node API

--- a/packages/babili/README.md
+++ b/packages/babili/README.md
@@ -7,7 +7,7 @@ Use `babili` if you don't already use babel (as a preset) or want to run it stan
 ## Installation
 
 ```sh
-$ npm install babili --save-dev
+npm install babili --save-dev
 ```
 
 ### Usage


### PR DESCRIPTION
Since we have a clipboard functionality on the website, we don't want the `$` anymore.

Also did in babel repo babel/babel#4910

Fixes babel/babel.github.io#1029