### PR TITLE
remove comments by default in babel-preset-babili

### DIFF
--- a/packages/babel-preset-babili/__tests__/preset-tests.js
+++ b/packages/babel-preset-babili/__tests__/preset-tests.js
@@ -39,4 +39,26 @@ describe("preset", () => {
     `);
     expect(transform(source)).toBe(expected);
   });
+
+  it("should fix remove comments", () => {
+    const source = unpad(`
+      var asdf = 1; // test
+    `);
+    const expected = unpad(`
+      var asdf = 1;
+    `);
+    expect(transform(source)).toBe(expected);
+  });
+
+  it("should keep license/preserve annotated comments", () => {
+    const source = unpad(`
+      /* @license */
+      var asdf = 1;
+    `);
+    const expected = unpad(`
+      /* @license */
+      var asdf = 1;
+    `);
+    expect(transform(source)).toBe(expected);
+  });
 });

--- a/packages/babel-preset-babili/src/index.js
+++ b/packages/babel-preset-babili/src/index.js
@@ -107,6 +107,7 @@ function preset(context, _opts = {}) {
 
   return {
     minified: true,
+    comments: false,
     presets: [
       { plugins }
     ],


### PR DESCRIPTION
Then we don't have to modify the readme unless we want to say somewhere it also removes comments.

This can be a bug fix (it was supposed to remove comments) or breaking change (it wasn't removing it before)

- [x] test