### PR TITLE
Split code block minify-mangle-names

### DIFF
--- a/packages/babel-plugin-minify-mangle-names/README.md
+++ b/packages/babel-plugin-minify-mangle-names/README.md
@@ -45,7 +45,9 @@ npm install babel-plugin-minify-mangle-names
 {
   "plugins": ["minify-mangle-names"]
 }
+```
 
+```json
 // with options
 {
   "plugins": ["minify-mangle-names", { "blacklist": { "foo": true, "bar": true} }]


### PR DESCRIPTION
Fixes babel/babel.github.io#1002 and following #328 