### PR TITLE
Improve examples in README.md

### DIFF
--- a/packages/babel-plugin-minify-dead-code-elimination/README.md
+++ b/packages/babel-plugin-minify-dead-code-elimination/README.md
@@ -12,8 +12,10 @@ function bar() { var x = f(); }
 function baz() {
   var x = 1;
   console.log(x);
+  function unused() {
+    return 5;
+  }
 }
-foo(0 && bar());
 ```
 
 **Out**
@@ -24,7 +26,6 @@ function bar() { f(); }
 function baz() {
   console.log(1);
 }
-foo(0);
 ```
 
 ## Installation


### PR DESCRIPTION
minify-dce doesn't transform `foo(0 && bar());` to `foo(0);` -- that minification is handled by minify-guarded-expressions.