### PR TITLE
Account for removal of consequent inside ternary for no-console plugin. Fixes #374

### DIFF
--- a/packages/babel-plugin-transform-remove-console/__tests__/remove-console-test.js
+++ b/packages/babel-plugin-transform-remove-console/__tests__/remove-console-test.js
@@ -89,4 +89,15 @@ describe("remove-console-plugin", () => {
     `);
     expect(transform(source).trim()).toBe(expected);
   });
+
+  it("ternary", () => {
+    const source = unpad(`
+      var foo = console.log ? console.log('lol') : someOtherFn;
+    `);
+
+    const expected = unpad(`
+      var foo = console.log ? () => {} : someOtherFn;
+    `);
+    expect(transform(source).trim()).toBe(expected);
+  });
 });

--- a/packages/babel-plugin-transform-remove-console/src/index.js
+++ b/packages/babel-plugin-transform-remove-console/src/index.js
@@ -1,12 +1,17 @@
 "use strict";
 
-module.exports = function() {
+module.exports = function({ types: t }) {
   return {
     name: "transform-remove-console",
     visitor: {
       CallExpression(path) {
-        if (path.get("callee").matchesPattern("console", true)) {
+        const isConsole = path.get("callee").matchesPattern("console", true);
+        const { parentPath } = path;
+
+        if ((parentPath.isExpressionStatement() || parentPath.isLogicalExpression()) && isConsole) {
           path.remove();
+        } else if (isConsole) {
+          path.replaceWith(t.arrowFunctionExpression([], t.blockStatement([])));
         }
       },
     },


### PR DESCRIPTION
Figured I'd take a whack at it.  The ideal minified form of this would probably be:
```js
// in
var foo = console.log ? console.log('lol') : someOtherFn;
// out
var foo = someOtherFn;
 ```

but I just went with what would fix the bug for now. Feedback welcome.