### PR TITLE
DCE: Deopt impure statements in If.test

### DIFF
--- a/packages/babel-plugin-minify-constant-folding/package.json
+++ b/packages/babel-plugin-minify-constant-folding/package.json
@@ -12,7 +12,8 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-helper-evaluate-path": "^0.0.3"
+    "babel-helper-evaluate-path": "^0.0.3",
+    "jsesc": "^2.4.0"
   },
   "devDependencies": {}
 }

--- a/packages/babel-plugin-minify-dead-code-elimination/__tests__/dead-code-elimination-test.js
+++ b/packages/babel-plugin-minify-dead-code-elimination/__tests__/dead-code-elimination-test.js
@@ -2421,4 +2421,13 @@ describe("dce-plugin", () => {
 
     expect(transform(source)).toBe(expected);
   });
+
+  it("should deopt impure expressions in if statements", () => {
+    const source = unpad(`
+      if (a.b(), true) {
+        foo();
+      }
+    `);
+    expect(transform(source)).toBe(source);
+  });
 });

--- a/packages/babel-plugin-minify-dead-code-elimination/__tests__/dead-code-elimination-test.js
+++ b/packages/babel-plugin-minify-dead-code-elimination/__tests__/dead-code-elimination-test.js
@@ -2422,12 +2422,42 @@ describe("dce-plugin", () => {
     expect(transform(source)).toBe(expected);
   });
 
-  it("should deopt impure expressions in if statements", () => {
+  it("should impure expressions in confidently evaluated if statements", () => {
     const source = unpad(`
       if (a.b(), true) {
         foo();
       }
     `);
-    expect(transform(source)).toBe(source);
+    const expected = unpad(`
+      a.b();
+
+      foo();
+    `);
+    expect(transform(source)).toBe(expected);
+  });
+
+  it("should extract all necessary things from if statements", () => {
+    const source = unpad(`
+      if (a.b(), false) {
+        var foo = foo1;
+        foo();
+      } else if (b.c(), true) {
+        var bar = bar1;
+        bar();
+      } else {
+        var baz = baz1;
+        baz();
+      }
+    `);
+    const expected = unpad(`
+      a.b();
+      b.c();
+
+      var bar = bar1;
+      bar();
+      var baz;
+      var foo;
+    `);
+    expect(transform(source)).toBe(expected);
   });
 });

--- a/packages/babel-preset-babili/__tests__/preset-tests.js
+++ b/packages/babel-preset-babili/__tests__/preset-tests.js
@@ -61,4 +61,18 @@ describe("preset", () => {
     `);
     expect(transform(source)).toBe(expected);
   });
+
+  it("should fix issue#385 - impure if statements with Sequence and DCE", () => {
+    const source = unpad(`
+      a = b;
+      c = d;
+      if (false) {
+        const x = y
+      }
+    `);
+    const expected = unpad(`
+      a = b, c = d;
+    `);
+    expect(transform(source)).toBe(expected);
+  });
 });


### PR DESCRIPTION
TODO:

+ [x] Test case for impure statements
+ [x] Preset test cases with other plugins ?

### Note:
**This moves IfStatement from program.traverse in DCE to DCEPlugin.visitor.**

+ (Fix #385)
+ Add isPure check to IfStatement visitor in DCE
+ Move IfStatement visitor from program.traverse to DCEPlugin.visitor - so that it executes for all IfStatements as babel traverse happens and NOT during the single pass within programPath.traverse in DCE. This eliminates the need for a second pass for things like the one mentioned in #385.