### PR TITLE
CallExpressions to TaggedTemplateLiterals

### DIFF
--- a/packages/babel-plugin-minify-simplify/__tests__/simplify-test.js
+++ b/packages/babel-plugin-minify-simplify/__tests__/simplify-test.js
@@ -37,9 +37,9 @@ const plugin = require("../src/index");
 const comparisonPlugin = require("../../babel-plugin-transform-simplify-comparison-operators/src");
 const unpad = require("../../../utils/unpad");
 
-function transform(code) {
+function transform(code, options) {
   return babel.transform(code,  {
-    plugins: [plugin],
+    plugins: [ [plugin, options] ],
   }).code;
 }
 
@@ -2642,5 +2642,20 @@ describe("simplify-plugin", () => {
       }).code;
     }
     expect(transform(source)).toBe(expected);
+  });
+
+  it("should convert call expressions with single string param to tagged templates", () => {
+    const source = unpad(`
+      foo("bar");
+      bar.baz("", "");
+      bar(a);
+      baz(5);
+      baz.foo.bar(4)("foo");
+      baz("bar", "")(5);
+      (() => {})("bar");
+      quux(foo(\`as\${d}f\`));
+    `);
+    const expected = "foo`bar`, bar.baz(\"\", \"\"), bar(a), baz(5), baz.foo.bar(4)`foo`, baz(\"bar\", \"\")(5), (() => {})`bar`, quux(foo(`as${ d }f`));";
+    expect(transform(source, { callsToTags: true })).toBe(expected);
   });
 });

--- a/packages/babel-plugin-minify-simplify/src/index.js
+++ b/packages/babel-plugin-minify-simplify/src/index.js
@@ -117,6 +117,37 @@ module.exports = ({ types: t }) => {
         }*/
       // },
 
+      CallExpression: {
+        enter: [
+          // Converts
+          // foo("bar") -> foo`bar`
+          function CallExprToTaggedTemplate(path, {
+            opts: {
+              ecmaVersion = 2015,
+              callsToTags = false
+            }
+          }) {
+            if (ecmaVersion < 2015 || !callsToTags) return;
+
+            const args = path.get("arguments");
+
+            if (args.length !== 1) return;
+            if (!args[0].isStringLiteral()) return;
+
+            const callee = path.get("callee");
+
+            path.replaceWith(
+              t.taggedTemplateExpression(
+                callee.node,
+                t.templateLiteral(
+                  [ t.templateElement({ raw: args[0].node.value }, true) ], []
+                )
+              )
+            );
+          }
+        ]
+      },
+
       UnaryExpression: {
         enter: [
 

--- a/packages/babel-preset-babili/src/index.js
+++ b/packages/babel-preset-babili/src/index.js
@@ -90,6 +90,10 @@ function preset(context, _opts = {}) {
       proxy("keepClassName", [
         optionsMap.mangle,
         optionsMap.deadcode
+      ]),
+
+      proxy("ecmaVersion", [
+        optionsMap.simplify
       ])
     ],
     "some"


### PR DESCRIPTION
+ Unsafe Transformation.
+ Adds option `simplify.callsToTags`
+ Adds option `ecmaVersion` (Default = 2015) to preset - now passed only to simplify. Can be used for other transformations later
+ Depends on https://github.com/babel/babel/issues/5192

Should we have this in some other plugin ? It can be present anywhere - nothing related to simplify (considering simplify already has too many transformations)