### PR TITLE
don't try and minify props that contain unicode

### DIFF
--- a/packages/babel-plugin-transform-property-literals/__tests__/transform-property-literals-test.js
+++ b/packages/babel-plugin-transform-property-literals/__tests__/transform-property-literals-test.js
@@ -50,4 +50,13 @@ describe("transform-property-literals-plugin", () => {
     `);
     expect(transform(source)).toBe(source);
   });
+
+  it("should not transform property keys that contain unicode", () => {
+    const source = unpad(`
+      ({
+        "\u2118": "wp"
+      });
+    `);
+    expect(transform(source)).toBe(source);
+  });
 });

--- a/packages/babel-plugin-transform-property-literals/src/index.js
+++ b/packages/babel-plugin-transform-property-literals/src/index.js
@@ -12,6 +12,11 @@ module.exports = function({ types: t }) {
             return;
           }
 
+          const containsUnicode = /[^a-z0-9$_]/i.test(key.value);
+          if (containsUnicode) {
+            return;
+          }
+
           if (key.value.match(/^\d+$/)) {
             node.key = t.numericLiteral(parseInt(node.key.value, 10));
             node.computed = false;


### PR DESCRIPTION
Firefox 50.1.0 (one behind latest stable) and Safari 10.0.2 (latest stable) are unable to parse object literal properties that contain unicode characters which are not valid ES5 identifiers.

The minifier saves bytes by converting objects such as `{ '\u2118':'wp' }` into `{℘:'wp'}`, which only works when the key is a valid identifier.

The fix involves bypassing any properties with string representation containing characters outside of the `a-zA-Z0-9_$` range.

Closes #415.
