### PR TITLE
chore(package): add description to babili package

### DIFF
--- a/packages/babili/package.json
+++ b/packages/babili/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babili",
   "version": "0.0.11",
-  "description": "",
+  "description": "✂️ An ES6+ aware minifier based on the Babel toolchain (beta)",
   "homepage": "https://github.com/babel/babili#readme",
   "repository": "https://github.com/babel/babili/tree/master/packages/babili",
   "bugs": "https://github.com/babel/babili/issues",


### PR DESCRIPTION
this info is exposed on yarnpkg.com, npmjs.com and others. If it's not filled in, the first part of the readme is used (which causes duplication).

This is the case in other packages here too. I'll make PRs for that if this one is merged. 