### PR TITLE
Simplify object and class methods

### DIFF
--- a/packages/babel-plugin-transform-property-literals/__tests__/transform-property-literals-test.js
+++ b/packages/babel-plugin-transform-property-literals/__tests__/transform-property-literals-test.js
@@ -16,8 +16,28 @@ describe("transform-property-literals-plugin", () => {
     const expected = "var x = { foo: 'bar' };";
     expect(transform(source)).toBe(expected);
   });
+  
+  it("should convert computed object method names with a string", () => {
+    const source = "var x = { ['foo'](){} };";
+    const expected = "var x = { 'foo'(){} };";
+    expect(transform(source)).toBe(expected);
+  });
+  
+  it("should convert computed class method names with a string", () => {
+	const source = unpad(`
+		class C {
+			['foo']() {}
+		}
+	`);
+	const expected = unpad(`
+		class C {
+			foo() {}
+		}
+	`);
+    expect(transform(source)).toBe(expected);
+  });
 
-  it("should strip unnecessary property literal qoutes for numbers", () => {
+  it("should strip unnecessary property literal quotes for numbers", () => {
     const source = "var x = { '1': 'bar' };";
     const expected = "var x = { 1: 'bar' };";
     expect(transform(source)).toBe(expected);

--- a/packages/babel-plugin-transform-property-literals/src/index.js
+++ b/packages/babel-plugin-transform-property-literals/src/index.js
@@ -21,6 +21,29 @@ module.exports = function({ types: t }) {
           }
         },
       },
+	  
+	  // ['foo']() {} -> foo() {}
+	  ClassMethod: {
+        exit({ node }) {
+          const key = node.key;
+		  
+          if (t.isStringLiteral(key) && t.isValidIdentifier(key.value)) {
+            node.key = t.identifier(key.value);
+            node.computed = false;
+          }
+        },
+      },
+	  
+	  ObjectMethod: {
+        exit({ node }) {
+          const key = node.key;
+		  
+          if (t.isStringLiteral(key) && t.isValidIdentifier(key.value)) {
+            node.key = t.identifier(key.value);
+            node.computed = false;
+          }
+        },
+      }
     },
   };
 };


### PR DESCRIPTION
Simplify object and class methods consistently with object properties.
Transforms `{ ["foo"]() {} }` to `{ foo() {} }` and `class C { ["foo"]()
{} }` to `class C { foo() {} }`. Includes tests.