### PR TITLE
Use absolute paths in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,11 +73,11 @@ If the syntax error occurs at runtime,  it likely means the code generator ([bab
 When you run your minified code in the browser,
 
 1. If there is an error in the console, as a first step, look around the code block where the error happens, and the code block of a few steps up in the stack.
-2. Try to predict what caused the error and try relating it to some of the plugin names in the [packages/](packages) directory. The major ones (that do a lot of transformations) are - mangle, deadcode-elimination and simplify.
-3. Every plugin that Babili uses has an option in preset to toggle it on/off - [preset-options](packages/babel-preset-babili#options)
+2. Try to predict what caused the error and try relating it to some of the plugin names in the [packages/](https://github.com/babel/babili/tree/master/packages) directory. The major ones (that do a lot of transformations) are - mangle, deadcode-elimination and simplify.
+3. Every plugin that Babili uses has an option in preset to toggle it on/off - [preset-options](https://github.com/babel/babili/tree/master/packages/babel-preset-babili#options)
 4. Disable any transformation(s) that you suspect are causing problems. Turning OFF mangling (`mangle: false`) is a good practice if you don't think it's related to a mangling bug, since unmangled variable names will make debugging easier.
 5. Sometimes it might NOT be a bug with one plugin but a combination of plugins. Again, `deadcode-elimination` and `simplify` maybe good candidates to start with here as they perform many transformations.
-6. Sometimes it might because of the [unsafe transformations](packages/babel-preset-babili#option-groups). Some of them are grouped into a single option named `unsafe`. This option can help you identify it sooner if the bug is in one these plugins.
+6. Sometimes it might because of the [unsafe transformations](https://github.com/babel/babili/tree/master/packages/babel-preset-babili#option-groups). Some of them are grouped into a single option named `unsafe`. This option can help you identify it sooner if the bug is in one these plugins.
 7. Produce a minimal repro of the same issue - the function block containing the bug should be enough to help reproduce the bug.
 8. [Report it 🙂](https://github.com/babel/babili/issues/new)
 9. You're awesome. Thanks!


### PR DESCRIPTION
Use absolute paths in `CONTRIBUTING.md` such that links will work on GitHub and the official website.