### PR TITLE
Fix Benchmark scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "chalk": "^1.1.3",
     "cli-table": "^0.3.1",
     "closure-compiler": "^0.2.12",
+    "commander": "^2.9.0",
     "eslint": "^3.16.1",
     "eslint-config-babel": "^6.0.0",
     "eslint-plugin-flowtype": "^2.29.2",
@@ -50,6 +51,7 @@
     "jest-cli": "^19.0.2",
     "lerna": "2.0.0-beta.38",
     "lerna-changelog": "^0.3.0",
+    "markdown-table": "^1.1.0",
     "request": "^2.80.0",
     "through2": "^2.0.1",
     "uglify-js": "^2.8.5"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "chalk": "^1.1.3",
     "cli-table": "^0.3.1",
     "closure-compiler": "^0.2.12",
-    "commander": "^2.9.0",
     "eslint": "^3.16.1",
     "eslint-config-babel": "^6.0.0",
     "eslint-plugin-flowtype": "^2.29.2",
@@ -51,6 +50,7 @@
     "jest-cli": "^19.0.2",
     "lerna": "2.0.0-beta.38",
     "lerna-changelog": "^0.3.0",
+    "request": "^2.80.0",
     "through2": "^2.0.1",
     "uglify-js": "^2.8.5"
   }

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,1 @@
+benchmark_cache

--- a/scripts/benchmark.js
+++ b/scripts/benchmark.js
@@ -12,239 +12,239 @@ const babel  = require("babel-core");
 const zlib   = require("zlib");
 const fs     = require("fs");
 const path   = require("path");
-const Command = require("commander").Command;
+const request = require("request");
 const compile = require("google-closure-compiler-js").compile;
 
-let packagename, filename;
+// constants
+const DEBUG = true;
+const ASSETS_DIR = path.join(__dirname, "benchmark_cache");
+const DEFAULT_ASSETS = {
+  "react.js"       : "https://unpkg.com/react/dist/react.js",
+  "vue.js"         : "https://unpkg.com/vue/dist/vue.js",
+  "jquery.js"      : "https://unpkg.com/jquery/dist/jquery.js",
+  "jquery.flot.js" : "https://unpkg.com/flot/jquery.flot.js",
+  "three.js"       : "https://unpkg.com/three/build/three.js",
+};
 
-const script = new Command("benchmark.js")
-  .option("-o, --offline", "Only install package if not present; package not removed after testing")
-  .option("-r, --runs <n>", "Number of times to run tests")
-  .option("-l, --local", "Use local file instead of a package")
-  .usage("[options] <package> [file]")
-  .arguments("<package> [file]")
-  .action(function(pname, fname, command) {
-    if (command.local) {
-      packagename = "";
-      filename = pname;
+class Benchmark {
+  constructor(files = [] /* absolute path of files */) {
+    this.files = files;
+    this.result = [];
+  }
+  run() {
+    this.files.forEach((file) => this.runFile(file));
+  }
+  runFile(filename) {
+    if (DEBUG) console.log(`Benchmark - ${filename}`);
+
+    const code = this.getFile(filename);
+    const gzipped = zlib.gzipSync(code);
+
+    const result = {
+      input: code,
+      gzipped,
+      filename,
+      items: [
+        this.test(this.babili, code),
+        this.test(this.uglify, code),
+        this.test(this.closureCompiler, filename, false),
+        this.test(this.closureCompilerJs, code),
+      ]
+    };
+
+    const min = Math.min(...result.items.map((item) => item.gzipped.length));
+    const max = Math.max(...result.items.map((item) => item.gzipped.length));
+
+    for (const item of result.items) {
+      if (item.gzipped.length === min) {
+        item.isMin = true;
+      }
+      if (item.gzipped.length === max) {
+        item.isMax = true;
+      }
     }
-    else {
-      packagename = pname;
-      filename = fname;
-    }
-  })
-  .parse(process.argv);
 
-if (!packagename && !script.local) {
-  console.error("Error: No package specified");
-  process.exit(1);
-}
-
-const numTestRuns = script.runs || 3;
-const pathToScripts = __dirname;
-
-const table = new Table({
-  head: ["", "raw", "raw win", "gzip", "gzip win", "parse time", "run time (average)"],
-  chars: {
-    top: "",
-    "top-mid": "",
-    "top-left": "",
-    "top-right": "",
-    bottom: "",
-    "bottom-mid": "",
-    "bottom-left": "",
-    "bottom-right": "",
-    left: "",
-    "left-mid": "",
-    mid: "",
-    "mid-mid": "",
-    right: "",
-    "right-mid": "",
-    middle: " ",
-  },
-  style: {
-    "padding-left": 0,
-    "padding-right": 0,
-    head: ["bold"],
-  },
-});
-
-let results = [],
-  code,
-  gzippedCode;
-
-function installPackage() {
-  const command = "npm install --prefix " + pathToScripts + " " + packagename;
-
-  try {
-    child.execSync(command);
+    this.result.push(result);
   }
-  catch (e) {
-	// Unecessary to print out error as the failure of the execSync will print it anyway
-    process.exit(1);
+  test(fn, arg, warmup = true) { // eslint-disable-line
+    if (DEBUG) console.log(`Running ${fn.name}`);
+
+    // warm up
+    // if (warmup) fn.call(null, arg);
+
+    const start = process.hrtime();
+    const output = fn.call(null, arg);
+    const delta = process.hrtime(start);
+
+    const gzipped = zlib.gzipSync(output);
+    const parseTime = this.getParseTime(output);
+
+    return {
+      name: fn.name,
+      output,
+      gzipped,
+      parseTime,
+      time: delta[0] * 1e3 + delta[1] / 1e6
+    };
   }
-}
-
-function uninstallPackage() {
-  const command = "npm uninstall --prefix " + pathToScripts + " " + packagename.split("@")[0];
-
-  try {
-    child.execSync(command);
-  }
-  catch (e) {
-    console.error("Error uninstalling package " + packagename + ": " + e);
-    process.exit(1);
-  }
-}
-
-function checkFile() {
-
-  if (!script.local) {
-    // If filename has not been passed as an argument, attempt to resolve file from package.json
-    filename = filename
-      ? path.join(pathToScripts, "node_modules", filename)
-      : require.resolve(packagename.split("@")[0]);
-  }
-
-  console.log("file: " + path.basename(filename));
-
-  if (!filename || !pathExists(filename)) {
-    console.error("File not found. Exiting.");
-    process.exit(1);
-  }
-}
-
-function test(name, callback) {
-
-  console.log("testing", name);
-
-  const start = Date.now();
-  const result = callback(code);
-  const end = Date.now();
-  const run = end - start;
-
-  fs.writeFileSync(".test_gen_" + name + ".js", result);
-
-  const gzipped = zlib.gzipSync(result);
-
-  const parseStart = Date.now();
-  new Function(result);
-  const parseEnd = Date.now();
-  const parseNow = parseEnd - parseStart;
-
-  const runTimes = [run];
-
-  for (let i = 1; i < numTestRuns; i++) {
-    const start = Date.now();
-    callback(code);
-    runTimes.push(Date.now() - start);
-  }
-
-  const totalTime = runTimes.reduce((a, b) => a + b, 0);
-  const average = parseInt(totalTime / runTimes.length, 10);
-
-  results.push({
-    name: name,
-    raw: result.length,
-    gzip: gzipped.length,
-    parse: parseNow,
-    run: average,
-  });
-}
-
-function testFile() {
-  code = fs.readFileSync(filename, "utf8");
-  gzippedCode = zlib.gzipSync(code);
-
-  test("babili (best speed)", function (code) {
+  babili(code) {
     return babel.transform(code, {
       sourceType: "script",
       presets: [require("../packages/babel-preset-babili")],
       comments: false,
     }).code;
-  });
-
-  test("babili (best size)", function (code) {
-    return babel.transform(code, {
-      sourceType: "script",
-      presets: [require("../packages/babel-preset-babili")],
-      comments: false,
+  }
+  uglify(code) {
+    return uglify.minify(code, {
+      fromString: true,
     }).code;
-  });
-
-  test("closure", function (/*code*/) {
+  }
+  closureCompiler(filename) {
     return child.execSync(
       "java -jar " + path.join(__dirname, "gcc.jar") +
       " --language_in=ECMASCRIPT5 --env=CUSTOM --jscomp_off=* --js " + filename
     ).toString();
-  });
-
-  test("closure js", function (code) {
+  }
+  closureCompilerJs(code) {
     const flags = {
       jsCode: [{ src: code }],
       env: "CUSTOM",
     };
     const out = compile(flags);
     return out.compiledCode;
-  });
-
-  test("uglify", function (code) {
-    return uglify.minify(code, {
-      fromString: true,
-    }).code;
-  });
-}
-
-function processResults() {
-  results = results.sort((a, b) => a.gzip > b.gzip);
-
-  results.forEach(function (result, i) {
-    let row = [
-      chalk.bold(result.name),
-      bytes(result.raw),
-      Math.round(((code.length / result.raw) * 100) - 100) + "%",
-      bytes(result.gzip),
-      Math.round(((gzippedCode.length / result.gzip) * 100) - 100) + "%",
-      Math.round(result.parse) + "ms",
-      Math.round(result.run) + "ms",
-    ];
-
-    let style = chalk.yellow;
-    if (i === 0) {
-      style = chalk.green;
-    }
-    if (i === results.length - 1) {
-      style = chalk.red;
-    }
-    row = row.map(function (item) {
-      return style(item);
-    });
-
-    table.push(row);
-  });
-
-  console.log(table.toString());
-}
-
-function pathExists(path) {
-  try {
-    return fs.statSync(path);
   }
-  catch (e) {
+  getParseTime(code) {
+    const start = process.hrtime();
+    exports.DUMMY = new Function(code);
+    const delta = process.hrtime(start);
+
+    return delta[0] * 1e3 + delta[1] / 1e6;
+  }
+  getFile(filename) {
+    return fs.readFileSync(filename, "utf-8").toString();
+  }
+}
+
+class AssetsManager {
+  constructor(assets, cacheDir) {
+    this.assets = assets;
+    this.cacheDir = cacheDir;
+  }
+  filePath(filename) {
+    return path.join(this.cacheDir, filename);
+  }
+  updateCache() {
+    if (DEBUG) console.log("Updating Cache...");
+    const files = Object.keys(this.assets);
+
+    return Promise.all(
+      files
+        .filter((filename) => !pathExists(this.filePath(filename)))
+        .map(
+          (filename) => this.download(
+            this.assets[filename], this.filePath(filename)
+          )
+        )
+    ).then(() => files.map((filename) => this.filePath(filename)));
+  }
+  download(url, dest) {
+    if (DEBUG) console.log(`Downloading ${url}`);
+
+    return new Promise((resolve, reject) => {
+      const file = fs.createWriteStream(dest);
+
+      request(url)
+        .pipe(file)
+        .on("error", (err) => {
+          fs.unlink(dest);
+          reject(err);
+        });
+
+      file.on("finish", () => file.close(resolve));
+    }).then(() => {
+      if (DEBUG) console.log(`Download Complete ${url}`);
+    });
+  }
+}
+
+function pathExists(file) {
+  try {
+    fs.statSync(file);
+    return true;
+  } catch (e) {
     return false;
   }
 }
 
-const packagePath = path.join(pathToScripts, "node_modules", packagename);
-
-if ((!pathExists(packagePath) || !script.offline) && !script.local) {
-  installPackage();
+function getTable() {
+  return new Table({
+    head: [
+      "minifier",
+      "output raw",
+      "raw win",
+      "gzip output",
+      "gzip win",
+      "parse time (ms)",
+      "minify time (ms)"
+    ],
+    chars: {
+      top: "", "top-left": "", "top-mid": "", "top-right": "",
+      left: "", "left-mid": "",
+      mid: "", "mid-mid": "",
+      right: "", "right-mid": "",
+      bottom: "", "bottom-left": "", "bottom-mid": "", "bottom-right": "",
+      middle: " | "
+    },
+    style: {
+      "padding-left": 0,
+      "padding-right": 0,
+      head: ["bold"],
+    },
+  });
 }
 
-checkFile();
-testFile();
-processResults();
+function run() {
+  const options = process.argv.slice(2);
 
-if (!script.offline && !script.local) {
-  uninstallPackage();
+  const prepare = options.length > 0
+    ? Promise.resolve(options)
+    : new AssetsManager(DEFAULT_ASSETS, ASSETS_DIR).updateCache();
+
+  prepare.then((files) => {
+    const benchmark = new Benchmark(files);
+    benchmark.run();
+
+    if (DEBUG) console.log("Generating results...");
+
+    // row: minifier, output raw, raw win, gzip output, gzip win, parse time, minify time,
+    for (const res of benchmark.result) {
+      const rows = res.items.map((item) => [
+        chalk.bold(item.name),
+        bytes(item.output.length),
+        Math.round(100 - 100 * item.output.length / res.input.length ) + "%",
+        bytes(item.gzipped.length),
+        Math.round(100 - 100 * item.gzipped.length / res.gzipped.length) + "%",
+        item.parseTime.toFixed(2),
+        item.time.toFixed(2)
+      ].map((col) => {
+        if (item.isMin) return chalk.green(col);
+        if (item.isMax) return chalk.red(col);
+        return col;
+      }));
+
+      const table = getTable();
+      table.push(...rows);
+
+      console.log(`\nBenchmark Results for ${path.basename(res.filename)}:`);
+      console.log(`Input Size: ${bytes(res.input.length)}`);
+      console.log(`Input Size (gzip): ${bytes(res.gzipped.length)}\n`);
+
+      console.log(table.toString());
+    }
+  }).catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
 }
+
+run();


### PR DESCRIPTION
+ (fix #465)

Outputs: 

```

Benchmark Results for react.js:
Input Size: 124.7kB
Input Size (gzip): 29.82kB

minifier          | output raw | raw win | gzip output | gzip win | parse time (ms) | minify time (ms)
babili            | 36.13kB    | 71%     | 12.6kB      | 58%      | 2.41            | 1862.94
uglify            | 35.73kB    | 71%     | 11.96kB     | 60%      | 2.32            | 820.07
closureCompiler   | 34.77kB    | 72%     | 11.96kB     | 60%      | 2.99            | 3388.90
closureCompilerJs | 65.41kB    | 48%     | 15.83kB     | 47%      | 3.00            | 1067.18

Benchmark Results for vue.js:
Input Size: 234.23kB
Input Size (gzip): 64.53kB

minifier          | output raw | raw win | gzip output | gzip win | parse time (ms) | minify time (ms)
babili            | 96.41kB    | 59%     | 34.55kB     | 46%      | 6.52            | 5632.69
uglify            | 88.9kB     | 62%     | 32.77kB     | 49%      | 6.43            | 1545.96
closureCompiler   | 86.94kB    | 63%     | 32.75kB     | 49%      | 7.00            | 6270.67
closureCompilerJs | 90.09kB    | 62%     | 33.67kB     | 48%      | 6.35            | 10337.66

Benchmark Results for jquery.js:
Input Size: 260.93kB
Input Size (gzip): 77.2kB

minifier          | output raw | raw win | gzip output | gzip win | parse time (ms) | minify time (ms)
babili            | 93.83kB    | 64%     | 32.1kB      | 58%      | 7.13            | 4851.06
uglify            | 84.92kB    | 67%     | 29.65kB     | 62%      | 6.47            | 1534.45
closureCompiler   | 85.7kB     | 67%     | 30.47kB     | 61%      | 7.55            | 6426.35
closureCompilerJs | 87.42kB    | 66%     | 31.13kB     | 60%      | 7.89            | 6563.06

Benchmark Results for jquery.flot.js:
Input Size: 107.43kB
Input Size (gzip): 23.91kB

minifier          | output raw | raw win | gzip output | gzip win | parse time (ms) | minify time (ms)
babili            | 36kB       | 66%     | 12.34kB     | 48%      | 2.61            | 1428.70
uglify            | 32.78kB    | 69%     | 11.54kB     | 52%      | 2.94            | 653.10
closureCompiler   | 31.91kB    | 70%     | 11.61kB     | 51%      | 2.55            | 3888.49
closureCompilerJs | 33.25kB    | 69%     | 12.08kB     | 49%      | 2.55            | 3627.37

Benchmark Results for three.js:
Input Size: 1002.36kB
Input Size (gzip): 199.96kB

minifier          | output raw | raw win | gzip output | gzip win | parse time (ms) | minify time (ms)
babili            | 526.27kB   | 47%     | 130.08kB    | 35%      | 31.33           | 15603.97
uglify            | 496.16kB   | 51%     | 123.99kB    | 38%      | 29.41           | 5200.65
closureCompiler   | 491.56kB   | 51%     | 124.93kB    | 38%      | 30.75           | 12573.82
closureCompilerJs | 499.81kB   | 50%     | 126.02kB    | 37%      | 28.13           | 73685.37
```