### PR TITLE
fix builtins plugins from leaking vars

### DIFF
--- a/packages/babel-plugin-minify-builtins/__tests__/__snapshots__/minify-builtins.js.snap
+++ b/packages/babel-plugin-minify-builtins/__tests__/__snapshots__/minify-builtins.js.snap
@@ -10,12 +10,13 @@ function a (){
     Math.min(b, a) * Math.floor(b);
   }
 }",
-  "expected": "var _Mathfloor = Math.floor;
-var _Mathmax = Math.max;
+  "expected": "var _Mathmax = Math.max;
 _Mathmax(a, b) + _Mathmax(a, b);
 function a() {
   _Mathmax(b, a);
   return function b() {
+    var _Mathfloor = Math.floor;
+
     const a = _Mathfloor(c);
     Math.min(b, a) * _Mathfloor(b);
   };
@@ -60,10 +61,11 @@ Object {
 function a () {
   return Math.PI + Math.PI + Number.EPSILON + Number.NAN;
 }",
-  "expected": "var _MathPI = Math.PI;
-var _NumberNAN = Number.NAN;
+  "expected": "var _NumberNAN = Number.NAN;
 _NumberNAN + _NumberNAN;
 function a() {
+  var _MathPI = Math.PI;
+
   return _MathPI + _MathPI + Number.EPSILON + _NumberNAN;
 }",
 }

--- a/packages/babel-plugin-minify-builtins/__tests__/__snapshots__/minify-builtins.js.snap
+++ b/packages/babel-plugin-minify-builtins/__tests__/__snapshots__/minify-builtins.js.snap
@@ -1,25 +1,72 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`minify-builtins should collect and minify no matter any depth 1`] = `
+exports[`minify-builtins should collect and minify in segments if there is no common ancestor 1`] = `
 Object {
-  "_source": "Math.max(a, b) + Math.max(a, b);
-function a (){
-  Math.max(b, a);
-  return function b() {
-    const a = Math.floor(c);
-    Math.min(b, a) * Math.floor(b);
+  "_source": "function a(){
+  function d(){
+    Math.floor(as, bb);
+  }
+}
+function b(){
+  Math.floor(as, bb);
+  function d(){
+    Math.floor(as, bb);
+  }
+}
+function c(){
+  Math.floor(as, bb);
+  function d(){
+    Math.floor(as, bb);
   }
 }",
-  "expected": "var _Mathmax = Math.max;
-_Mathmax(a, b) + _Mathmax(a, b);
-function a() {
-  _Mathmax(b, a);
-  return function b() {
+  "expected": "function a() {
+  function d() {
+    Math.floor(as, bb);
+  }
+}
+function b() {
+  var _Mathfloor = Math.floor;
+
+  _Mathfloor(as, bb);
+  function d() {
+    _Mathfloor(as, bb);
+  }
+}
+function c() {
+  var _Mathfloor2 = Math.floor;
+
+  _Mathfloor2(as, bb);
+  function d() {
+    _Mathfloor2(as, bb);
+  }
+}",
+}
+`;
+
+exports[`minify-builtins should collect and minify no matter any depth 1`] = `
+Object {
+  "_source": "function a (){
+  Math.max(b, a);
+  function b() {
+    const a = Math.floor(c);
+    Math.min(b, a) * Math.floor(b);
+    function c() {
+      Math.floor(c) + Math.min(b, a)
+    }
+  }
+}",
+  "expected": "function a() {
+  Math.max(b, a);
+  function b() {
+    var _Mathmin = Math.min;
     var _Mathfloor = Math.floor;
 
     const a = _Mathfloor(c);
-    Math.min(b, a) * _Mathfloor(b);
-  };
+    _Mathmin(b, a) * _Mathfloor(b);
+    function c() {
+      _Mathfloor(c) + _Mathmin(b, a);
+    }
+  }
 }",
 }
 `;
@@ -39,17 +86,18 @@ foo(x);",
 
 exports[`minify-builtins should minify standard built in methods 1`] = `
 Object {
-  "_source": "Math.max(a, b) + Math.max(b, a);
-function c() {
+  "_source": "function c() {
   let a = 10;
   const d = Number.isNaN(a);
+  Math.max(a, b) + Math.max(b, a);
   return d && Number.isFinite(a);
 }",
-  "expected": "var _Mathmax = Math.max;
-_Mathmax(a, b) + _Mathmax(b, a);
-function c() {
+  "expected": "function c() {
+  var _Mathmax = Math.max;
+
   let a = 10;
   const d = false;
+  _Mathmax(a, b) + _Mathmax(b, a);
   return d && true;
 }",
 }
@@ -57,15 +105,15 @@ function c() {
 
 exports[`minify-builtins should minify standard built in properties 1`] = `
 Object {
-  "_source": "Number.NAN + Number.NAN;
-function a () {
+  "_source": "function a () {
+  Number.NAN + Number.NAN;
   return Math.PI + Math.PI + Number.EPSILON + Number.NAN;
 }",
-  "expected": "var _NumberNAN = Number.NAN;
-_NumberNAN + _NumberNAN;
-function a() {
+  "expected": "function a() {
   var _MathPI = Math.PI;
+  var _NumberNAN = Number.NAN;
 
+  _NumberNAN + _NumberNAN;
   return _MathPI + _MathPI + Number.EPSILON + _NumberNAN;
 }",
 }
@@ -92,13 +140,29 @@ Math[max](1.5);",
 exports[`minify-builtins should take no of occurences in to account 1`] = `
 Object {
   "_source": "function a() {
-  return Math.floor(a) + Math.floor(b) + Math.min(a, b);
+  Math.floor(a) + Math.floor(b) + Math.min(a, b);
+}",
+  "expected": "function a() {
+  var _Mathfloor = Math.floor;
+
+  _Mathfloor(a) + _Mathfloor(b) + Math.min(a, b);
+}",
 }
-Math.floor(a) + Math.max(a, b);",
-  "expected": "var _Mathfloor = Math.floor;
+`;
+
+exports[`minify-builtins shouldn't minify builtins in the program scope to avoid leaking 1`] = `
+Object {
+  "_source": "Math.max(c, d)
+function a (){
+  Math.max(b, a) + Math.max(c, d);
+}
+Math.max(e, f)",
+  "expected": "Math.max(c, d);
 function a() {
-  return _Mathfloor(a) + _Mathfloor(b) + Math.min(a, b);
+  var _Mathmax = Math.max;
+
+  _Mathmax(b, a) + _Mathmax(c, d);
 }
-_Mathfloor(a) + Math.max(a, b);",
+Math.max(e, f);",
 }
 `;

--- a/packages/babel-plugin-minify-builtins/src/index.js
+++ b/packages/babel-plugin-minify-builtins/src/index.js
@@ -29,11 +29,7 @@ module.exports = function({ types: t }) {
 
           if (!isComputed(path) && isBuiltin(path)) {
             const expName = memberToString(path.node);
-
-            if (!context.pathsToUpdate.has(expName)) {
-              context.pathsToUpdate.set(expName, []);
-            }
-            context.pathsToUpdate.get(expName).push(path);
+            addToMap(context.pathsToUpdate, expName, path);
           }
         },
 
@@ -55,11 +51,7 @@ module.exports = function({ types: t }) {
                 path.replaceWith(t.valueToNode(result.value));
               } else {
                 const expName = memberToString(callee.node);
-
-                if (!context.pathsToUpdate.has(expName)) {
-                  context.pathsToUpdate.set(expName, []);
-                }
-                context.pathsToUpdate.get(expName).push(callee);
+                addToMap(context.pathsToUpdate, expName, callee);
               }
             }
           }
@@ -71,21 +63,39 @@ module.exports = function({ types: t }) {
 
     replace() {
       for (const [expName, paths] of this.pathsToUpdate) {
-        // Should only transform if there is more than 1 occurence
-        if (paths.length > 1) {
+        // transform only if there is more than 1 occurence
+        if (paths.length <= 1) {
+          continue;
+        }
+
+        // occurences that has program scope are not minified
+        // to avoid leaking identifiers
+        const validPaths = paths.filter(p => {
+          return !p.getFunctionParent().isProgram();
+        });
+
+        // Early exit here as well
+        if (validPaths.length <= 1) {
+          continue;
+        }
+
+        const segmentsMap = getSegmentedSubPaths(expName, validPaths);
+        for (const [parent, subpaths] of segmentsMap) {
+          if (subpaths.length <= 1) {
+            continue;
+          }
           const uniqueIdentifier = this.program.scope.generateUidIdentifier(
             expName
           );
           const newNode = t.variableDeclaration("var", [
-            t.variableDeclarator(uniqueIdentifier, paths[0].node)
+            t.variableDeclarator(uniqueIdentifier, subpaths[0].node)
           ]);
 
-          for (const path of paths) {
+          for (const path of subpaths) {
             path.replaceWith(uniqueIdentifier);
           }
-          // hoist the created var to the top of the block/program
-          const path = getLeastCommonFunctionPath(paths[0], paths[paths.length - 1]);
-          path.unshiftContainer("body", newNode);
+          // hoist the created var to the top of the function scope
+          parent.get("body").unshiftContainer("body", newNode);
         }
       }
     }
@@ -127,32 +137,41 @@ module.exports = function({ types: t }) {
   }
 };
 
-function getLeastCommonFunctionPath(firstPath, lastPath) {
-  let resultPath;
-  const firstParent = firstPath.getFunctionParent();
-  const lastParent = lastPath.getFunctionParent();
-
-  const { node: { start : firstStart } } = firstParent;
-  const { node: { start : lastStart } } = lastParent;
-
-  // Early optimization that avoids the situation when firstPath
-  // is too deep in the tree and lastPath is one level deep and vice versa
-  if (firstStart < lastStart) {
-    resultPath = firstParent;
-  } else {
-    resultPath = lastParent;
+function addToMap(map, key, value) {
+  if (!map.has(key)) {
+    map.set(key, []);
   }
-  // Traverse bottom up till it finds the common ancestor
-  while (!(firstPath.isDescendant(resultPath) &&
-    lastPath.isDescendant(resultPath))) {
-    resultPath = resultPath.getFunctionParent();
-  }
+  map.get(key).push(value);
+}
 
-  if (resultPath.isProgram()) {
-    return resultPath;
-  }
-  // return the block statment if its not program
-  return resultPath.get("body");
+// Creates a segmented map that contains the earliest common Ancestor
+// as the key and array of subpaths that are descendats of the LCA as value
+function getSegmentedSubPaths(expName, paths) {
+  let segments = new Map();
+
+  // Get earliest Path in tree where paths intersect
+  paths[
+    0
+  ].getDeepestCommonAncestorFrom(paths, (lastCommon, index, ancestries) => {
+    // we found the LCA
+    if (!lastCommon.isProgram()) {
+      lastCommon = !lastCommon.isFunction()
+        ? lastCommon.getFunctionParent()
+        : lastCommon;
+      segments.set(lastCommon, paths);
+      return;
+    }
+    // Deopt and construct segments otherwise
+    for (const ancestor of ancestries) {
+      const parentPath = ancestor[index + 1];
+      const validDescendants = paths.filter(p => {
+        return p.isDescendant(parentPath);
+      });
+      segments.set(parentPath, validDescendants);
+    }
+  });
+
+  return segments;
 }
 
 function hasPureArgs(path) {

--- a/packages/babel-plugin-minify-mangle-names/src/index.js
+++ b/packages/babel-plugin-minify-mangle-names/src/index.js
@@ -260,8 +260,8 @@ module.exports = ({ types: t, traverse }) => {
           const mangler = new Mangler(charset, path, this.opts);
           mangler.run();
         }
-      },
-    },
+      }
+    }
   };
 };
 

--- a/packages/babel-plugin-minify-mangle-names/src/index.js
+++ b/packages/babel-plugin-minify-mangle-names/src/index.js
@@ -247,19 +247,21 @@ module.exports = ({ types: t, traverse }) => {
   return {
     name: "minify-mangle-names",
     visitor: {
-      Program(path) {
-        // If the source code is small then we're going to assume that the user
-        // is running on this on single files before bundling. Therefore we
-        // need to achieve as much determinisim and we will not do any frequency
-        // sorting on the character set. Currently the number is pretty arbitrary.
-        const shouldConsiderSource = path.getSource().length > 70000;
+      Program: {
+        exit(path) {
+          // If the source code is small then we're going to assume that the user
+          // is running on this on single files before bundling. Therefore we
+          // need to achieve as much determinisim and we will not do any frequency
+          // sorting on the character set. Currently the number is pretty arbitrary.
+          const shouldConsiderSource = path.getSource().length > 70000;
 
-        const charset = new Charset(shouldConsiderSource);
+          const charset = new Charset(shouldConsiderSource);
 
-        const mangler = new Mangler(charset, path, this.opts);
-        mangler.run();
-      }
-    }
+          const mangler = new Mangler(charset, path, this.opts);
+          mangler.run();
+        }
+      },
+    },
   };
 };
 

--- a/packages/babel-preset-babili/__tests__/preset-tests.js
+++ b/packages/babel-preset-babili/__tests__/preset-tests.js
@@ -114,25 +114,21 @@ describe("preset", () => {
 
   it("should fix issue#425 - mangles the alaises from builtins transform", () => {
     const source = unpad(`
-      function foo (){
-        const d = Math.max(b, a);
-        return function b() {
-          const a = Math.floor(c);
-          Math.max(b, a) * Math.floor(b);
+      function a (){
+        const d = Math.max(foo, bar);
+        function b() {
+          Math.max(foo, bar) * Math.floor(baz);
+        }
+        function c() {
+          Math.max(foo, bar) * Math.floor(baz);
         }
       }
     `);
     const expected = unpad(`
-      function foo() {
-        var d = Math.max;
-        d(b, a);
-
-        return function e() {
-          var f = Math.floor;
-
-          const g = f(c);
-          d(e, g) * f(e);
-        };
+      function a() {
+        var b = Math.floor,
+            c = Math.max;
+        c(foo, bar);
       }
     `);
     expect(transform(source)).toBe(expected);

--- a/packages/babel-preset-babili/__tests__/preset-tests.js
+++ b/packages/babel-preset-babili/__tests__/preset-tests.js
@@ -111,4 +111,31 @@ describe("preset", () => {
     );
     expect(transform(source)).toBe(expected);
   });
+
+  it("should fix issue#425 - mangles the alaises from builtins transform", () => {
+    const source = unpad(`
+      function foo (){
+        const d = Math.max(b, a);
+        return function b() {
+          const a = Math.floor(c);
+          Math.max(b, a) * Math.floor(b);
+        }
+      }
+    `);
+    const expected = unpad(`
+      function foo() {
+        var d = Math.max;
+        d(b, a);
+
+        return function e() {
+          var f = Math.floor;
+
+          const g = f(c);
+          d(e, g) * f(e);
+        };
+      }
+    `);
+    expect(transform(source)).toBe(expected);
+  });
+
 });

--- a/packages/babel-preset-babili/__tests__/preset-tests.js
+++ b/packages/babel-preset-babili/__tests__/preset-tests.js
@@ -113,7 +113,8 @@ describe("preset", () => {
   });
 
   it("should fix issue#425 - mangles the alaises from builtins transform", () => {
-    const source = unpad(`
+    const source = unpad(
+      `
       function a (){
         const d = Math.max(foo, bar);
         function b() {
@@ -123,15 +124,17 @@ describe("preset", () => {
           Math.max(foo, bar) * Math.floor(baz);
         }
       }
-    `);
-    const expected = unpad(`
+    `
+    );
+    const expected = unpad(
+      `
       function a() {
         var b = Math.floor,
             c = Math.max;
         c(foo, bar);
       }
-    `);
+    `
+    );
     expect(transform(source)).toBe(expected);
   });
-
 });


### PR DESCRIPTION
fix #461 
+ The implementation decides where to insert the created identifier based on the input code. 

Even after fixing this, the mangler doesn't rename the identifier properly. Related - https://github.com/babel/babili/issues/425