### PR TITLE
Create benchmark_cache dir if it doesn't exist

### DIFF
--- a/scripts/benchmark.js
+++ b/scripts/benchmark.js
@@ -257,6 +257,8 @@ class AssetsManager {
     if (DEBUG) console.error("Updating Cache...");
     const files = Object.keys(this.assets);
 
+    if (!pathExists(this.cacheDir)) fs.mkdirSync(this.cacheDir);
+
     return Promise.all(
       files
         .filter(filename => !pathExists(this.filePath(filename)))


### PR DESCRIPTION
Create benchmark_cache directory if it doesn't exist before downloading the default packages.