### PR TITLE
Set static coverage % & disable patch

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,3 +2,9 @@ coverage:
   parsers:
     javascript:
       enable_partials: yes
+  status:
+    project:
+      default:
+        target: "80%"
+    patch:
+      enabled: false


### PR DESCRIPTION
Related: https://github.com/babel/babel/pull/5619

We face the same issues where a small coverage drop marks the PR red.

