### PR TITLE
Fix mangling of Named Exports in Modules

### DIFF
--- a/packages/babel-plugin-minify-mangle-names/__tests__/mangle-names-test.js
+++ b/packages/babel-plugin-minify-mangle-names/__tests__/mangle-names-test.js
@@ -1325,4 +1325,45 @@ describe("mangle-names", () => {
     );
     expect(transform(source, { topLevel: true })).toBe(source);
   });
+
+  it("should not mangle named exports - 1", () => {
+    const source = unpad(
+      `
+      export const Foo = foo;
+    `
+    );
+    expect(transform(source, { topLevel: true }, "module")).toBe(source);
+  });
+
+  it("should not mangle named exports - 2", () => {
+    const source = unpad(
+      `
+      const Foo = a;
+      export {Foo};
+    `
+    );
+    const expected = unpad(
+      `
+      const b = a;
+      export { b as Foo };
+    `
+    );
+    expect(transform(source, { topLevel: true }, "module")).toBe(expected);
+  });
+
+  it("should not mangle named exports - 3", () => {
+    const source = unpad(
+      `
+      const Foo = a;
+      export {Foo as Bar};
+    `
+    );
+    const expected = unpad(
+      `
+      const b = a;
+      export { b as Bar };
+    `
+    );
+    expect(transform(source, { topLevel: true }, "module")).toBe(expected);
+  });
 });

--- a/packages/babel-plugin-minify-mangle-names/src/index.js
+++ b/packages/babel-plugin-minify-mangle-names/src/index.js
@@ -88,6 +88,24 @@ module.exports = ({ types: t, traverse }) => {
       }
     }
 
+    isExportedWithName(binding) {
+      // short circuit
+      if (!this.topLevel) {
+        return false;
+      }
+
+      const refs = binding.referencePaths;
+
+      for (const ref of refs) {
+        if (ref.isExportNamedDeclaration()) {
+          return true;
+        }
+      }
+
+      // default
+      return false;
+    }
+
     mangleScope(scope) {
       const mangler = this;
 
@@ -139,7 +157,9 @@ module.exports = ({ types: t, traverse }) => {
           // function names
           (mangler.keepFnName ? isFunction(binding.path) : false) ||
           // class names
-          (mangler.keepClassName ? isClass(binding.path) : false)
+          (mangler.keepClassName ? isClass(binding.path) : false) ||
+          // named export
+          mangler.isExportedWithName(binding)
         ) {
           continue;
         }


### PR DESCRIPTION
+ Ref #479

This completes one part of the problem where now Named exports are no
more mangled. But the other part, where we can convert

```js
const foo = bar;
export {foo};
```

to

```js
export const foo = bar;
```

is yet to be explored in DCE or other plugins.