### PR TITLE
Fix collapse with circular reference

### DIFF
--- a/packages/babel-plugin-transform-inline-consecutive-adds/__tests__/transform-inline-consecutive-adds-test.js
+++ b/packages/babel-plugin-transform-inline-consecutive-adds/__tests__/transform-inline-consecutive-adds-test.js
@@ -212,6 +212,16 @@ describe("transform-inline-consecutive-adds-plugin", () => {
     expect(transform(source)).toBe(source);
   });
 
+  it("should not collapse computed properties with circular reference", () => {
+    const source = unpad(
+      `
+      var foo = {};
+      foo.bar = foo;
+    `
+    );
+    expect(transform(source)).toBe(source);
+  });
+
   it("should collapse statements with multiple assignments", () => {
     const source = unpad(
       `
@@ -289,6 +299,16 @@ describe("transform-inline-consecutive-adds-plugin", () => {
     `
     );
     expect(transform(source)).toBe(expected);
+  });
+
+  it("should not collapse statements for array-initialized sets with circular reference", () => {
+    const source = unpad(
+      `
+      var foo = new Set([1, 2]);
+      foo.add(foo);
+    `
+    );
+    expect(transform(source)).toBe(source);
   });
 
   it("should collapse array property assignments", () => {
@@ -372,5 +392,15 @@ describe("transform-inline-consecutive-adds-plugin", () => {
     `
     );
     expect(transform(source)).toBe(expected);
+  });
+
+  it("should not collapse array property assignments if it is circular reference", () => {
+    const source = unpad(
+      `
+      var foo = [];
+      foo[2] = foo;
+    `
+    );
+    expect(transform(source)).toBe(source);
   });
 });

--- a/packages/babel-plugin-transform-inline-consecutive-adds/src/index.js
+++ b/packages/babel-plugin-transform-inline-consecutive-adds/src/index.js
@@ -142,7 +142,7 @@ function getContiguousStatementsAndExpressions(
 
 function getReferenceChecker(references) {
   // returns a function s.t. given an expr, returns true iff expr is an ancestor of a reference
-  return expr => references.some(r => r.isDescendant(expr));
+  return expr => references.some(r => r === expr || r.isDescendant(expr));
 }
 
 function tryUseCollapser(t, collapser, varDecl, topLevel, checkReference) {

--- a/packages/babel-plugin-transform-inline-consecutive-adds/src/set-collapser.js
+++ b/packages/babel-plugin-transform-inline-consecutive-adds/src/set-collapser.js
@@ -44,7 +44,7 @@ class SetCollapser extends Collapser {
       if (args.length !== 1) {
         return false;
       }
-      if (checkReference(args)) {
+      if (checkReference(args[0])) {
         return false;
       }
       return true;


### PR DESCRIPTION
This PR fix the bug for:

```js
var foo = {};
foo.bar = foo;

var foo2 = [];
foo2[2] = foo2;

var foo3 = new Set([])
foo3.add(foo3)
```

Will convert to:

```js
var foo = {bar:foo};

var foo2 = [,,foo2];

var foo3 = new Set([foo3])
```

It will get `undefined` for `var`, a ReferenceError for `let` and `const`.

I catched the problem with [`prop-types`](https://github.com/reactjs/prop-types/blob/master/factoryWithThrowingShims.js#L51) module.