### PR TITLE
handle deopt case in builtins properly

### DIFF
--- a/packages/babel-plugin-minify-builtins/__tests__/__snapshots__/minify-builtins.js.snap
+++ b/packages/babel-plugin-minify-builtins/__tests__/__snapshots__/minify-builtins.js.snap
@@ -1,30 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`minify-builtins should collect and minify in segments if there is no common ancestor 1`] = `
+exports[`minify-builtins should collect and minify in segments in any depth if there is no LCA 1`] = `
 Object {
-  "_source": "function a(){
-  function d(){
-    Math.floor(as, bb);
-  }
-}
-function b(){
+  "_source": "function b(){
   Math.floor(as, bb);
   function d(){
     Math.floor(as, bb);
   }
 }
-function c(){
-  Math.floor(as, bb);
-  function d(){
-    Math.floor(as, bb);
+const a = {
+  c : () => {
+      Math.floor(bbb);
+      Math.floor(bbb);
+  },
+  d : () => {
+      Math.abs(aa);
+      Math.abs(aa);
+      Math.floor(aa);
+      return () => {
+        Math.floor(aa);
+      }
   }
-}",
-  "expected": "function a() {
-  function d() {
-    Math.floor(as, bb);
+};
+class A {
+  constructor() {
+    let a = Math.floor(b,c) + Math.floor(b,c);
   }
-}
-function b() {
+  c() {
+      Math.floor(asdas);
+      Math.floor(dasda);
+  }
+  d() {
+    var a = Math.floor;
+      a(aa, bb);
+      Math.floor(aa, bb);
+  }
+};
+new A()",
+  "expected": "function b() {
   var _Mathfloor = Math.floor;
 
   _Mathfloor(as, bb);
@@ -32,14 +45,46 @@ function b() {
     _Mathfloor(as, bb);
   }
 }
-function c() {
-  var _Mathfloor2 = Math.floor;
+const a = {
+  c: () => {
+    var _Mathfloor2 = Math.floor;
 
-  _Mathfloor2(as, bb);
-  function d() {
-    _Mathfloor2(as, bb);
+    _Mathfloor2(bbb);
+    _Mathfloor2(bbb);
+  },
+  d: () => {
+    var _Mathabs = Math.abs;
+    var _Mathfloor3 = Math.floor;
+
+    _Mathabs(aa);
+    _Mathabs(aa);
+    _Mathfloor3(aa);
+    return () => {
+      _Mathfloor3(aa);
+    };
   }
-}",
+};
+class A {
+  constructor() {
+    var _Mathfloor4 = Math.floor;
+
+    let a = _Mathfloor4(b, c) + _Mathfloor4(b, c);
+  }
+  c() {
+    var _Mathfloor5 = Math.floor;
+
+    _Mathfloor5(asdas);
+    _Mathfloor5(dasda);
+  }
+  d() {
+    var _Mathfloor6 = Math.floor;
+
+    var a = _Mathfloor6;
+    a(aa, bb);
+    _Mathfloor6(aa, bb);
+  }
+};
+new A();",
 }
 `;
 
@@ -103,11 +148,11 @@ A.b(\\"asdas1\\", function() {
   Math.max(e,d);
 })",
   "expected": "var a = () => {
+  var _Mathfloor = Math.floor;
+
   _Mathfloor(b);
   _Mathfloor(b);
   c: () => {
-    var _Mathfloor = Math.floor;
-
     _Mathfloor(d);
     2;
   };

--- a/packages/babel-plugin-minify-builtins/__tests__/__snapshots__/minify-builtins.js.snap
+++ b/packages/babel-plugin-minify-builtins/__tests__/__snapshots__/minify-builtins.js.snap
@@ -47,7 +47,7 @@ exports[`minify-builtins should collect and minify no matter any depth 1`] = `
 Object {
   "_source": "function a (){
   Math.max(b, a);
-  function b() {
+  const b = () => {
     const a = Math.floor(c);
     Math.min(b, a) * Math.floor(b);
     function c() {
@@ -57,7 +57,7 @@ Object {
 }",
   "expected": "function a() {
   Math.max(b, a);
-  function b() {
+  const b = () => {
     var _Mathmin = Math.min;
     var _Mathfloor = Math.floor;
 
@@ -66,7 +66,7 @@ Object {
     function c() {
       _Mathfloor(c) + _Mathmin(b, a);
     }
-  }
+  };
 }",
 }
 `;
@@ -81,6 +81,90 @@ foo(x);",
 let b = 1.8;
 let x = 5;
 foo(x);",
+}
+`;
+
+exports[`minify-builtins should minify builtins to function scopes  1`] = `
+Object {
+  "_source": "var a = () => {
+  Math.floor(b);
+  Math.floor(b);
+  c: () => {
+    Math.floor(d);
+    Math.max(2,1);
+  }
+}
+A.b(\\"asdas\\", function() {
+  Math.floor(d) + Math.max(d,e);
+  Math.max(e,d);
+})
+A.b(\\"asdas1\\", function() {
+  Math.floor(d) + Math.floor(d,e);
+  Math.max(e,d);
+})",
+  "expected": "var a = () => {
+  _Mathfloor(b);
+  _Mathfloor(b);
+  c: () => {
+    var _Mathfloor = Math.floor;
+
+    _Mathfloor(d);
+    2;
+  };
+};
+A.b(\\"asdas\\", function () {
+  var _Mathmax = Math.max;
+
+  Math.floor(d) + _Mathmax(d, e);
+  _Mathmax(e, d);
+});
+A.b(\\"asdas1\\", function () {
+  var _Mathfloor2 = Math.floor;
+
+  _Mathfloor2(d) + _Mathfloor2(d, e);
+  Math.max(e, d);
+});",
+}
+`;
+
+exports[`minify-builtins should minify builtins to method scope for class declarations 1`] = `
+Object {
+  "_source": "class Test {
+  foo() {
+    Math.max(c, d)
+    Math.max(c, d)
+    const c = function() {
+      Math.max(c, d)
+      Math.floor(m);
+      Math.floor(m);
+    }
+  }
+  bar() {
+    Math.min(c, d)
+    Math.min(c, d)
+  }
+}",
+  "expected": "class Test {
+  foo() {
+    var _Mathmax = Math.max;
+
+    _Mathmax(c, d);
+    _Mathmax(c, d);
+    const c = function () {
+      var _Mathfloor = Math.floor;
+
+      _Mathmax(c, d);
+      _Mathfloor(m);
+      _Mathfloor(m);
+    };
+  }
+  bar() {
+    var _Mathmin = Math.min;
+
+    _Mathmin(c, d);
+    _Mathmin(c, d);
+  }
+}",
 }
 `;
 

--- a/packages/babel-plugin-minify-builtins/__tests__/__snapshots__/minify-builtins.js.snap
+++ b/packages/babel-plugin-minify-builtins/__tests__/__snapshots__/minify-builtins.js.snap
@@ -9,10 +9,7 @@ Object {
   }
 }
 const a = {
-  c : () => {
-      Math.floor(bbb);
-      Math.floor(bbb);
-  },
+  c : () => Math.floor(bbb) + Math.floor(bbb) ,
   d : () => {
       Math.abs(aa);
       Math.abs(aa);
@@ -20,7 +17,8 @@ const a = {
       return () => {
         Math.floor(aa);
       }
-  }
+  },
+  e : () => Math.abs(aa) + Math.abs(aa)
 };
 class A {
   constructor() {
@@ -46,42 +44,38 @@ new A()",
   }
 }
 const a = {
-  c: () => {
-    var _Mathfloor2 = Math.floor;
-
-    _Mathfloor2(bbb);
-    _Mathfloor2(bbb);
-  },
+  c: () => Math.floor(bbb) + Math.floor(bbb),
   d: () => {
     var _Mathabs = Math.abs;
-    var _Mathfloor3 = Math.floor;
+    var _Mathfloor2 = Math.floor;
 
     _Mathabs(aa);
     _Mathabs(aa);
-    _Mathfloor3(aa);
+    _Mathfloor2(aa);
     return () => {
-      _Mathfloor3(aa);
+      _Mathfloor2(aa);
     };
-  }
+  },
+  e: () => Math.abs(aa) + Math.abs(aa)
 };
 class A {
   constructor() {
-    var _Mathfloor4 = Math.floor;
+    var _Mathfloor3 = Math.floor;
 
-    let a = _Mathfloor4(b, c) + _Mathfloor4(b, c);
+    let a = _Mathfloor3(b, c) + _Mathfloor3(b, c);
   }
   c() {
-    var _Mathfloor5 = Math.floor;
+    var _Mathfloor4 = Math.floor;
 
-    _Mathfloor5(asdas);
-    _Mathfloor5(dasda);
+    _Mathfloor4(asdas);
+    _Mathfloor4(dasda);
   }
   d() {
-    var _Mathfloor6 = Math.floor;
+    var _Mathfloor5 = Math.floor;
 
-    var a = _Mathfloor6;
+    var a = _Mathfloor5;
     a(aa, bb);
-    _Mathfloor6(aa, bb);
+    _Mathfloor5(aa, bb);
   }
 };
 new A();",
@@ -254,6 +248,13 @@ Object {
 Math.random();",
   "expected": "Math.max(foo(), 1);
 Math.random();",
+}
+`;
+
+exports[`minify-builtins should not minify for arrow fn without block statment 1`] = `
+Object {
+  "_source": "const a = () => Math.floor(b) + Math.floor(b);",
+  "expected": "const a = () => Math.floor(b) + Math.floor(b);",
 }
 `;
 

--- a/packages/babel-plugin-minify-builtins/__tests__/minify-builtins.js
+++ b/packages/babel-plugin-minify-builtins/__tests__/minify-builtins.js
@@ -127,26 +127,44 @@ describe("minify-builtins", () => {
     expect({ _source: source, expected: transform(source) }).toMatchSnapshot();
   });
 
-  it("should collect and minify in segments if there is no common ancestor", () => {
+  it("should collect and minify in segments in any depth if there is no LCA", () => {
     const source = unpad(
       `
-      function a(){
-        function d(){
-          Math.floor(as, bb);
-        }
-      }
       function b(){
         Math.floor(as, bb);
         function d(){
           Math.floor(as, bb);
         }
       }
-      function c(){
-        Math.floor(as, bb);
-        function d(){
-          Math.floor(as, bb);
+      const a = {
+        c : () => {
+            Math.floor(bbb);
+            Math.floor(bbb);
+        },
+        d : () => {
+            Math.abs(aa);
+            Math.abs(aa);
+            Math.floor(aa);
+            return () => {
+              Math.floor(aa);
+            }
         }
-      }
+      };
+      class A {
+        constructor() {
+          let a = Math.floor(b,c) + Math.floor(b,c);
+        }
+        c() {
+            Math.floor(asdas);
+            Math.floor(dasda);
+        }
+        d() {
+          var a = Math.floor;
+            a(aa, bb);
+            Math.floor(aa, bb);
+        }
+      };
+      new A()
     `
     );
     expect({ _source: source, expected: transform(source) }).toMatchSnapshot();

--- a/packages/babel-plugin-minify-builtins/__tests__/minify-builtins.js
+++ b/packages/babel-plugin-minify-builtins/__tests__/minify-builtins.js
@@ -54,7 +54,7 @@ describe("minify-builtins", () => {
       `
       function a (){
         Math.max(b, a);
-        function b() {
+        const b = () => {
           const a = Math.floor(c);
           Math.min(b, a) * Math.floor(b);
           function c() {
@@ -75,6 +75,53 @@ describe("minify-builtins", () => {
         Math.max(b, a) + Math.max(c, d);
       }
       Math.max(e, f)
+    `
+    );
+    expect({ _source: source, expected: transform(source) }).toMatchSnapshot();
+  });
+
+  it("should minify builtins to method scope for class declarations", () => {
+    const source = unpad(
+      `
+      class Test {
+        foo() {
+          Math.max(c, d)
+          Math.max(c, d)
+          const c = function() {
+            Math.max(c, d)
+            Math.floor(m);
+            Math.floor(m);
+          }
+        }
+        bar() {
+          Math.min(c, d)
+          Math.min(c, d)
+        }
+      }
+    `
+    );
+    expect({ _source: source, expected: transform(source) }).toMatchSnapshot();
+  });
+
+  it("should minify builtins to function scopes ", () => {
+    const source = unpad(
+      `
+      var a = () => {
+        Math.floor(b);
+        Math.floor(b);
+        c: () => {
+          Math.floor(d);
+          Math.max(2,1);
+        }
+      }
+      A.b("asdas", function() {
+        Math.floor(d) + Math.max(d,e);
+        Math.max(e,d);
+      })
+      A.b("asdas1", function() {
+        Math.floor(d) + Math.floor(d,e);
+        Math.max(e,d);
+      })
     `
     );
     expect({ _source: source, expected: transform(source) }).toMatchSnapshot();

--- a/packages/babel-plugin-minify-builtins/__tests__/minify-builtins.js
+++ b/packages/babel-plugin-minify-builtins/__tests__/minify-builtins.js
@@ -137,10 +137,7 @@ describe("minify-builtins", () => {
         }
       }
       const a = {
-        c : () => {
-            Math.floor(bbb);
-            Math.floor(bbb);
-        },
+        c : () => Math.floor(bbb) + Math.floor(bbb) ,
         d : () => {
             Math.abs(aa);
             Math.abs(aa);
@@ -148,7 +145,8 @@ describe("minify-builtins", () => {
             return () => {
               Math.floor(aa);
             }
-        }
+        },
+        e : () => Math.abs(aa) + Math.abs(aa)
       };
       class A {
         constructor() {
@@ -197,6 +195,15 @@ describe("minify-builtins", () => {
       `
       let max = "floor";
       Math[max](1.5);
+    `
+    );
+    expect({ _source: source, expected: transform(source) }).toMatchSnapshot();
+  });
+
+  it("should not minify for arrow fn without block statment", () => {
+    const source = unpad(
+      `
+      const a = () => Math.floor(b) + Math.floor(b);
     `
     );
     expect({ _source: source, expected: transform(source) }).toMatchSnapshot();

--- a/packages/babel-plugin-minify-builtins/src/index.js
+++ b/packages/babel-plugin-minify-builtins/src/index.js
@@ -148,27 +148,27 @@ function getSegmentedSubPaths(paths) {
     paths,
     (lastCommon, index, ancestries) => {
       // found the LCA
-      if (!lastCommon.isProgram() && lastCommon.isFunction()) {
-        segments.set(lastCommon, paths);
-        return;
-      }
-      // Found the LCA in the parent
-      let funParent = lastCommon.getFunctionParent();
-      if (!(lastCommon.isProgram() || funParent.isProgram())) {
-        segments.set(funParent, paths);
-        return;
+      if (!lastCommon.isProgram()) {
+        let fnParent;
+        if (lastCommon.isFunction()) {
+          segments.set(lastCommon, paths);
+          return;
+        } else if (!(fnParent = lastCommon.getFunctionParent()).isProgram()) {
+          segments.set(fnParent, paths);
+          return;
+        }
       }
 
       // Deopt and construct segments otherwise
       for (const ancestor of ancestries) {
-        const funcPath = getChildFuncion(ancestor);
-        if (funcPath === void 0) {
+        const fnPath = getChildFuncion(ancestor);
+        if (fnPath === void 0) {
           return;
         }
         const validDescendants = paths.filter(p => {
-          return p.isDescendant(funcPath);
+          return p.isDescendant(fnPath);
         });
-        segments.set(funcPath, validDescendants);
+        segments.set(fnPath, validDescendants);
       }
     }
   );
@@ -181,7 +181,6 @@ function getChildFuncion(ancestors = []) {
       return path;
     }
   }
-  return void 0;
 }
 
 function hasPureArgs(path) {

--- a/packages/babel-plugin-minify-builtins/src/index.js
+++ b/packages/babel-plugin-minify-builtins/src/index.js
@@ -150,20 +150,25 @@ function getSegmentedSubPaths(paths) {
       // found the LCA
       if (!lastCommon.isProgram()) {
         let fnParent;
-        if (lastCommon.isFunction()) {
+        if (
+          lastCommon.isFunction() &&
+          lastCommon.get("body").isBlockStatement()
+        ) {
           segments.set(lastCommon, paths);
           return;
-        } else if (!(fnParent = lastCommon.getFunctionParent()).isProgram()) {
+        } else if (
+          !(fnParent = lastCommon.getFunctionParent()).isProgram() &&
+          fnParent.get("body").isBlockStatement()
+        ) {
           segments.set(fnParent, paths);
           return;
         }
       }
-
       // Deopt and construct segments otherwise
       for (const ancestor of ancestries) {
         const fnPath = getChildFuncion(ancestor);
         if (fnPath === void 0) {
-          return;
+          continue;
         }
         const validDescendants = paths.filter(p => {
           return p.isDescendant(fnPath);
@@ -177,7 +182,7 @@ function getSegmentedSubPaths(paths) {
 
 function getChildFuncion(ancestors = []) {
   for (const path of ancestors) {
-    if (path.isFunction()) {
+    if (path.isFunction() && path.get("body").isBlockStatement()) {
       return path;
     }
   }

--- a/packages/babel-plugin-minify-builtins/src/index.js
+++ b/packages/babel-plugin-minify-builtins/src/index.js
@@ -140,32 +140,33 @@ module.exports = function({ types: t }) {
     let segments = new Map();
 
     // Get earliest Path in tree where paths intersect
-    paths[
-      0
-    ].getDeepestCommonAncestorFrom(paths, (lastCommon, index, ancestries) => {
-      // we found the LCA
-      if (!(lastCommon.isProgram() || lastCommon.isClassBody())) {
-        lastCommon = !lastCommon.isFunction()
-          ? lastCommon.getFunctionParent()
-          : lastCommon;
-        segments.set(lastCommon, paths);
-        return;
-      }
-      // Deopt and construct segments otherwise
-      // Hold node references to avoid traversal incase of same subpaths
-      let wm = new WeakMap();
-      for (const ancestor of ancestries) {
-        let parentPath = ancestor[index + 1];
-        const validDescendants = paths.filter(p => {
-          return p.isDescendant(parentPath);
-        });
-
-        if (!parentPath.isFunction()) {
-          parentPath = getChildFunction(parentPath.node, wm);
+    paths[0].getDeepestCommonAncestorFrom(
+      paths,
+      (lastCommon, index, ancestries) => {
+        // we found the LCA
+        if (!(lastCommon.isProgram() || lastCommon.isClassBody())) {
+          lastCommon = !lastCommon.isFunction()
+            ? lastCommon.getFunctionParent()
+            : lastCommon;
+          segments.set(lastCommon, paths);
+          return;
         }
-        segments.set(parentPath, validDescendants);
+        // Deopt and construct segments otherwise
+        // Hold node references to avoid traversal incase of same subpaths
+        let wm = new WeakMap();
+        for (const ancestor of ancestries) {
+          let parentPath = ancestor[index + 1];
+          const validDescendants = paths.filter(p => {
+            return p.isDescendant(parentPath);
+          });
+
+          if (!parentPath.isFunction()) {
+            parentPath = getChildFunction(parentPath.node, wm);
+          }
+          segments.set(parentPath, validDescendants);
+        }
       }
-    });
+    );
     return segments;
   }
 


### PR DESCRIPTION
+ Deopt case was not there for classBody
+ handle the case when creating segments when the parentPath is not a function. 
+ fix #458 
+ fix #529 