### PR TITLE
Failing test: builtins and mangle conflict

### DIFF
--- a/packages/babel-preset-babili/__tests__/preset-tests.js
+++ b/packages/babel-preset-babili/__tests__/preset-tests.js
@@ -131,4 +131,19 @@ describe("preset", () => {
     `);
     expect(transform(source)).toBe(expected);
   });
+
+  it("should fix bug#TBD - builtins and mangle conflict", () => {
+    const source = unpad(`
+      function a() {
+        foo([Math.pi, Math.pi]);
+      }
+    `);
+    const expected = unpad(`
+      function a() {
+        var a = Math.pi;
+        foo([a, a]);
+      }
+    `);
+    expect(transform(source)).toBe(expected);
+  });
 });

--- a/packages/babel-preset-babili/__tests__/preset-tests.js
+++ b/packages/babel-preset-babili/__tests__/preset-tests.js
@@ -135,15 +135,15 @@ describe("preset", () => {
   it("should fix bug#TBD - builtins and mangle conflict", () => {
     const source = unpad(`
       function a() {
-        foo([Math.pi, Math.pi]);
+        [Math.pi, Math.pi];
       }
     `);
     const expected = unpad(`
       function a() {
         var a = Math.pi;
-        foo([a, a]);
+        [a, a];
       }
     `);
-    expect(transform(source)).toBe(expected);
+    expect(transform(source, { deadcode: false })).toBe(expected);
   });
 });


### PR DESCRIPTION
🚨  This pull request contains a failing test and should not be merged.

This demonstrates a conflict between `babel-plugin-minify-builtins` and `babel-plugin-minify-mangle-names`. When a property on `Math` or `Number` is referenced twice in an array literal inside a function, only the second reference gets updated with the mangled name.

```js
// in.js
function a() {
    [Math.pi, Math.pi];
}
```

```js
// out.js
function a() {
    var a = Math.pi;
    [_Mathpi, a];
}
```

This appears to happen only for `Math` or `Number` properties - I tried `Array`, `Boolean`, `Date`, and a few others, none of which had this issue.

Just the `builtins` and `mangle-names` plugins are sufficient to reproduce the problem. In this test, I had to wrap the array in the call to `foo` to avoid dead code elimination getting rid of the array entirely. Is there a better place to add tests that is just two those two plugins?