### PR TITLE
Add workaround for Safari for loop lexical scope bug

### DIFF
--- a/packages/babel-plugin-minify-mangle-names/src/scope-tracker.js
+++ b/packages/babel-plugin-minify-mangle-names/src/scope-tracker.js
@@ -137,19 +137,15 @@ module.exports = class ScopeTracker {
         maybeFor.isForXStatement({ left: maybeDecl.node });
       if (isForLoopBinding) {
         const fnParent = maybeFor.getFunctionParent();
-        if (fnParent.isFunction()) {
-          const parentScope = maybeFor.scope.parent;
-          const isIncorrectlyTopLevelInSafari = parentScope === fnParent.scope;
-          if (isIncorrectlyTopLevelInSafari) {
-            const parentFunctionBinding = this.bindings
-              .get(parentScope)
-              .get(next);
-            if (parentFunctionBinding) {
-              const parentFunctionHasParamBinding =
-                parentFunctionBinding.kind === "param";
-              if (parentFunctionHasParamBinding) {
-                return false;
-              }
+        if (fnParent.isFunction({ body: maybeFor.parent })) {
+          const parentFunctionBinding = this.bindings
+            .get(fnParent.scope)
+            .get(next);
+          if (parentFunctionBinding) {
+            const parentFunctionHasParamBinding =
+              parentFunctionBinding.kind === "param";
+            if (parentFunctionHasParamBinding) {
+              return false;
             }
           }
         }


### PR DESCRIPTION
Safari raises a syntax error for a `let` or `const` declaration in a `for` loop initalization that shadows a parent function's parameter:

```js
function a(b) {
  for (let b;;);
}
```

This is valid code, but Safari throws a syntax error. The bug has been [reported](https://bugs.webkit.org/show_bug.cgi?id=171041) and since [fixed](https://trac.webkit.org/changeset/217200/webkit/trunk/Source) in WebKit, so future versions of Safari will not have this problem.

This modifies the scope tracker's `canUseInReferencedScopes` method to detect cases where a rename would trigger this bug and use a different name.

Fixes #559 

This is my first time dealing with Babel internals, so please let me know if there's a better way to do this!