### PR TITLE
Fix #576

### DIFF
--- a/packages/babel-plugin-minify-constant-folding/__tests__/constant-folding-test.js
+++ b/packages/babel-plugin-minify-constant-folding/__tests__/constant-folding-test.js
@@ -237,4 +237,18 @@ describe("constant-folding-plugin", () => {
     );
     expect(transform(source)).toBe(expected);
   });
+
+  it("shouldn’t crash on toString() calls or accesses", () => {
+    const source = unpad(
+      `
+      "foo".toString()
+      ["foo", "bar"].toString()
+      {}.toString()
+      "foo".toString
+      ["foo", "bar"].toString
+      {}.toString
+      `
+    )
+    expect(transform(source)).toBe(source);
+  })
 });

--- a/packages/babel-plugin-minify-constant-folding/__tests__/constant-folding-test.js
+++ b/packages/babel-plugin-minify-constant-folding/__tests__/constant-folding-test.js
@@ -248,7 +248,7 @@ describe("constant-folding-plugin", () => {
       ["foo", "bar"].toString;
       ({}).toString;
       `
-    )
+    );
     expect(transform(source)).toBe(source);
-  })
+  });
 });

--- a/packages/babel-plugin-minify-constant-folding/__tests__/constant-folding-test.js
+++ b/packages/babel-plugin-minify-constant-folding/__tests__/constant-folding-test.js
@@ -243,10 +243,10 @@ describe("constant-folding-plugin", () => {
       `
       "foo".toString()
       ["foo", "bar"].toString()
-      {}.toString()
+      ({}).toString()
       "foo".toString
       ["foo", "bar"].toString
-      {}.toString
+      ({}).toString
       `
     )
     expect(transform(source)).toBe(source);

--- a/packages/babel-plugin-minify-constant-folding/__tests__/constant-folding-test.js
+++ b/packages/babel-plugin-minify-constant-folding/__tests__/constant-folding-test.js
@@ -241,12 +241,12 @@ describe("constant-folding-plugin", () => {
   it("shouldn’t crash on toString() calls or accesses", () => {
     const source = unpad(
       `
-      "foo".toString()
-      ["foo", "bar"].toString()
-      ({}).toString()
-      "foo".toString
-      ["foo", "bar"].toString
-      ({}).toString
+      "foo".toString();
+      ["foo", "bar"].toString();
+      ({}).toString();
+      "foo".toString;
+      ["foo", "bar"].toString;
+      ({}).toString;
       `
     )
     expect(transform(source)).toBe(source);

--- a/packages/babel-plugin-minify-constant-folding/src/index.js
+++ b/packages/babel-plugin-minify-constant-folding/src/index.js
@@ -22,7 +22,10 @@ function swap(path, member, handlers, ...args) {
   const key = getName(member);
   if (key === undefined) return;
   let handler = handlers[key];
-  if (typeof handler !== "function" || !Object.hasOwnProperty.call(handlers, key)) {
+  if (
+    typeof handler !== "function" ||
+    !Object.hasOwnProperty.call(handlers, key)
+  ) {
     if (typeof handlers[FALLBACK_HANDLER] === "function") {
       handler = handlers[FALLBACK_HANDLER].bind(member.object, key);
     } else {

--- a/packages/babel-plugin-minify-constant-folding/src/index.js
+++ b/packages/babel-plugin-minify-constant-folding/src/index.js
@@ -22,7 +22,7 @@ function swap(path, member, handlers, ...args) {
   const key = getName(member);
   if (key === undefined) return;
   let handler = handlers[key];
-  if (typeof handler !== "function") {
+  if (typeof handler !== "function" || !Object.hasOwnProperty.call(handlers, key)) {
     if (typeof handlers[FALLBACK_HANDLER] === "function") {
       handler = handlers[FALLBACK_HANDLER].bind(member.object, key);
     } else {


### PR DESCRIPTION
People were calling `"foo".toString()` or `["foo", "bar"].toString()`, which returned the real JS string `"[object Object]"`, the stringified version of the replacements object. Fixes #576.

---

I just noticed this:
```js
[foo, bar].toString() // is longer than
[foo, bar].join(',')
```