### PR TITLE
[fix #574] deopt when binding is present in diff scope

### DIFF
--- a/packages/babel-plugin-minify-dead-code-elimination/__tests__/dead-code-elimination-test.js
+++ b/packages/babel-plugin-minify-dead-code-elimination/__tests__/dead-code-elimination-test.js
@@ -2462,4 +2462,14 @@ describe("dce-plugin", () => {
       }
     `
   );
+
+  thePlugin(
+    "should deopt when binding is on different scope - issue #574",
+    `
+      function foo(v) {
+        if (v) var w = 10;
+        if (w) console.log("hello", v);
+      }
+    `
+  );
 });

--- a/packages/babel-plugin-minify-dead-code-elimination/src/index.js
+++ b/packages/babel-plugin-minify-dead-code-elimination/src/index.js
@@ -776,16 +776,15 @@ module.exports = ({ types: t, traverse }) => {
           const evalResult = test.evaluate();
           const isPure = test.isPure();
 
-          const { path: bindingPath } =
-            path.scope.getBinding(test.node.name) || {};
+          const binding = path.scope.getBinding(test.node.name);
 
           // Ref - https://github.com/babel/babili/issues/574
           // deopt if var is declared in other scope
           // if (a) { var b = blahl;} if (b) { //something }
           if (
-            bindingPath &&
-            bindingPath.parentPath.isVariableDeclaration() &&
-            isDifferentScope(bindingPath.parentPath, path)
+            binding &&
+            binding.path.parentPath.isVariableDeclaration() &&
+            isDifferentScope(binding.path.parentPath, path)
           ) {
             return;
           }


### PR DESCRIPTION
+ Fix #574 

this is required for only var bindings. 

The other way we could fix this is to hoist all the var bindings before we run simplify & deadcode. 