### PR TITLE
Convert simple arrow function body to expression

### DIFF
--- a/packages/babel-plugin-minify-simplify/__tests__/simplify-test.js
+++ b/packages/babel-plugin-minify-simplify/__tests__/simplify-test.js
@@ -2488,4 +2488,28 @@ describe("simplify-plugin", () => {
     }
   `
   );
+
+  thePlugin(
+    "should convert simple arrow block to expression",
+    `
+    const a = () => {return (3, 4);};
+    const b = () => {return 3;};
+  `,
+    `
+    const a = () => (3, 4);
+    const b = () => 3;
+  `
+  );
+
+  thePlugin(
+    "should NOT convert empty arrow block to expression",
+    `
+    const a = () => {};
+    const b = () => {return;};
+  `,
+    `
+    const a = () => {};
+    const b = () => {};
+  `
+  );
 });

--- a/packages/babel-plugin-minify-simplify/src/index.js
+++ b/packages/babel-plugin-minify-simplify/src/index.js
@@ -782,7 +782,6 @@ module.exports = ({ types: t }) => {
 
           if (
             t.isArrowFunctionExpression(parent) &&
-            node.body &&
             node.body.length === 1 &&
             t.isReturnStatement(node.body[0]) &&
             node.body[0].argument !== null

--- a/packages/babel-plugin-minify-simplify/src/index.js
+++ b/packages/babel-plugin-minify-simplify/src/index.js
@@ -780,6 +780,17 @@ module.exports = ({ types: t }) => {
         exit(path) {
           const { node, parent } = path;
 
+          if (
+            t.isArrowFunctionExpression(parent) &&
+            node.body &&
+            node.body.length === 1 &&
+            t.isReturnStatement(node.body[0]) &&
+            node.body[0].argument !== null
+          ) {
+            path.replaceWith(node.body[0].argument);
+            return;
+          }
+
           if (needsBlock(node, parent)) {
             return;
           }


### PR DESCRIPTION
Eliminate unnecessary `return` keyword by converting arrow function block statements to expressions where possible.

Example:
```js
const foo = () => {
  return (1, 2);
};
const bar = () => {
  return [];
};

// becomes
const foo = () => (1, 2);
const bar = () => [];
```