### PR TITLE
[1046] Maintain source mapping for merged sibling vars.

### DIFF
--- a/packages/babel-plugin-transform-merge-sibling-variables/package.json
+++ b/packages/babel-plugin-transform-merge-sibling-variables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-transform-merge-sibling-variables",
-  "version": "6.9.6",
+  "version": "6.9.5",
   "description": "Merge sibling variables into one.",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-merge-sibling-variables/package.json
+++ b/packages/babel-plugin-transform-merge-sibling-variables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-transform-merge-sibling-variables",
-  "version": "6.9.5",
+  "version": "6.9.6",
   "description": "Merge sibling variables into one.",
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-merge-sibling-variables/src/index.js
+++ b/packages/babel-plugin-transform-merge-sibling-variables/src/index.js
@@ -55,11 +55,15 @@ module.exports = function({ types: t }) {
 
             const { node } = path;
 
+            node.declarations.forEach(d => d.loc = d.loc || node.loc);
+
             let sibling = path.getSibling(path.key + 1);
 
             let declarations = [];
 
             while (sibling.isVariableDeclaration({ kind: node.kind })) {
+              sibling.node.declarations.forEach(d => d.loc = d.loc || sibling.node.loc);
+
               declarations = declarations.concat(sibling.node.declarations);
 
               sibling.remove();


### PR DESCRIPTION
The plugin babel-plugin-transform-merge-sibling-variables does not maintain source mapping when merging sibling variable declarators into a single declaration after babel-plugin-transform-modules-commonjs has been applied.

To Reproduce:
Minify a file that has been processed with babel-plugin-transform-modules-commonjs. If the original file has more than one import statement, the mapping will be lost.

Minimal code to reproduce the bug: https://github.com/babel/minify/issues/1046
