### PR TITLE
support StaticBlock

### DIFF
--- a/packages/babel-helper-evaluate-path/src/index.js
+++ b/packages/babel-helper-evaluate-path/src/index.js
@@ -168,7 +168,7 @@ function evaluateBasedOnControlFlow(binding, refPath) {
     }
 
     // Detect usage before init
-    const stmts = fnParent.isProgram()
+    const stmts = fnParent.isProgram() || fnParent.isStaticBlock()
       ? fnParent.node.body
       : fnParent.node.body.body;
 


### PR DESCRIPTION
```javascript
class Foo{
	static {
      
    }
}
```

```json
{
	"type": "StaticBlock",
	"start": 12,
	"end": 33,
	"loc": {
		"start": {
			"line": 2,
			"column": 1,
			"index": 12
		},
		"end": {
			"line": 4,
			"column": 5,
			"index": 33
		}
	},
	"body": []
}
```

`fnParent.node.body.body` get undefined